### PR TITLE
Validator procs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ class OrdersSearch
 end
 ```
 
+### :validator
+
+Pass a validator proc or lambda which will be called with the supplied value. Values for which true is returned will be allowed. Values for which false is returned will be ignored, or the default used if available.
+
+```ruby
+class OrdersSearch
+  include Parametric::Params
+  param :shoe_count, 'Number of shoes', validator: ->(n) { n.even? }, default: 2
+end
+```
+
 ### :multiple values
 
 `:multiple` values are separated on "," and treated as arrays.

--- a/lib/parametric/params.rb
+++ b/lib/parametric/params.rb
@@ -43,13 +43,14 @@ module Parametric
     def _reduce(raw_params)
       self.class._allowed_params.each_with_object(ParamsHash.new) do |(key,options),memo|
         policy = Policies::Policy.new((raw_params.has_key?(key) ? raw_params[key] : []), options)
-        policy = policy.wrap(Policies::CoercePolicy)   if options[:coerce]
-        policy = policy.wrap(Policies::NestedPolicy)   if options[:nested]
-        policy = policy.wrap(Policies::MultiplePolicy) if options[:multiple]
-        policy = policy.wrap(Policies::OptionsPolicy)  if options[:options]
-        policy = policy.wrap(Policies::MatchPolicy)    if options[:match]
-        policy = policy.wrap(Policies::DefaultPolicy)  if options.has_key?(:default)
-        policy = policy.wrap(Policies::SinglePolicy)   unless options[:multiple]
+        policy = policy.wrap(Policies::CoercePolicy)    if options[:coerce]
+        policy = policy.wrap(Policies::NestedPolicy)    if options[:nested]
+        policy = policy.wrap(Policies::MultiplePolicy)  if options[:multiple]
+        policy = policy.wrap(Policies::OptionsPolicy)   if options[:options]
+        policy = policy.wrap(Policies::MatchPolicy)     if options[:match]
+        policy = policy.wrap(Policies::ValidatorPolicy) if options[:validator]
+        policy = policy.wrap(Policies::DefaultPolicy)   if options.has_key?(:default)
+        policy = policy.wrap(Policies::SinglePolicy)    unless options[:multiple]
         memo[key] = policy.value
       end
     end

--- a/lib/parametric/policies.rb
+++ b/lib/parametric/policies.rb
@@ -80,5 +80,12 @@ module Parametric
       end
     end
 
+    class ValidatorPolicy < Policy
+      def value
+        decorated.value.each_with_object([]){|a,arr|
+          arr << a if options[:validator].call(a)
+        }
+      end
+    end
   end
 end

--- a/spec/parametric_spec.rb
+++ b/spec/parametric_spec.rb
@@ -89,6 +89,14 @@ describe Parametric do
     it 'does not accept single option if not in declared options' do
       klass.new(country: 'USA').params[:country].should be_nil
     end
+
+    it 'accepts value if validator returns true' do
+      klass.new(even_number: 2).params[:even_number].should == 2
+    end
+
+    it 'does not accept value if validator returns false' do
+      klass.new(even_number: 3).params[:even_number].should == nil
+    end
   end
 
   describe 'TypedParams' do
@@ -103,6 +111,7 @@ describe Parametric do
         string :country, 'country', options: ['UK', 'CL', 'JPN']
         string :email, 'email', match: /\w+@\w+\.\w+/
         array :emails, 'emails', match: /\w+@\w+\.\w+/, default: 'default@email.com'
+        integer :even_number, 'even number', validator: ->(n) { n.even? }
       end
     end
 
@@ -124,6 +133,7 @@ describe Parametric do
         param :email, 'email', match: /\w+@\w+\.\w+/
         param :emails, 'emails', match: /\w+@\w+\.\w+/, multiple: true, default: 'default@email.com'
         param :available, 'available', default: true
+        param :even_number, 'even number', validator: ->(n) { n.even? }
       end
     end
 
@@ -196,6 +206,9 @@ describe Parametric do
         subject.schema[:emails].value.should == 'default@email.com'
         subject.schema[:emails].multiple.should be_true
         subject.schema[:emails].match.should == regexp
+
+        subject.schema[:even_number].label.should == 'even number'
+        subject.schema[:even_number].value.should == ''
       end
     end
   end


### PR DESCRIPTION
Adds support for specifying a more complex validation with a proc or lambda (actually anything which responds to `#call`). Example:

```
class OrdersSearch
   include Parametric::Params
   param :shoe_count, 'Number of shoes', validator: ->(n) { n.even? }, default: 2
 end
```

The block should return true for allowed values and false for non-allowed values.

Opening this PR for discussion of this feature. I'm not sure if the interface is exactly right. I've gone for a separate attribute of the param (`validator`) rather than extending say `match` to take a regexp or a proc. It feels like since `match` and `options` are already separate, `validator` is another sibling of those two. I also wonder if `validator` is the best name.

Let me know what you think!