### PR TITLE
Param definitions are inherited to subclasses

### DIFF
--- a/lib/parametric/params.rb
+++ b/lib/parametric/params.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'support/class_attribute'
 module Parametric
 
   class ParamsHash < Hash
@@ -13,6 +14,8 @@ module Parametric
 
     def self.included(base)
       base.send(:attr_reader, :params)
+      base.class_attribute :_allowed_params
+      base._allowed_params = {}
       base.extend DSL
     end
 
@@ -55,8 +58,14 @@ module Parametric
     end
 
     module DSL
-      def _allowed_params
-        @allowed_params ||= {}
+
+      # When subclasses params definitions
+      # we want to copy parent class definitions
+      # so changes in the child class
+      # don't mutate the parent definitions
+      #
+      def inherited(subclass)
+        subclass._allowed_params = self._allowed_params.dup
       end
 
       def param(field_name, label = '', opts = {}, &block)

--- a/lib/support/class_attribute.rb
+++ b/lib/support/class_attribute.rb
@@ -1,0 +1,68 @@
+begin
+  require 'active_support/core_ext/class/attribute'
+rescue LoadError
+  module Kernel
+    # Returns the object's singleton class.
+    def singleton_class
+      class << self
+        self
+      end
+    end unless respond_to?(:singleton_class) # exists in 1.9.2
+
+    # class_eval on an object acts like singleton_class.class_eval.
+    def class_eval(*args, &block)
+      singleton_class.class_eval(*args, &block)
+    end
+  end
+
+  class Module
+    def remove_possible_method(method)
+      if method_defined?(method) || private_method_defined?(method)
+        remove_method(method)
+      end
+    rescue NameError
+      # If the requested method is defined on a superclass or included module,
+      # method_defined? returns true but remove_method throws a NameError.
+      # Ignore this.
+    end
+
+    def redefine_method(method, &block)
+      remove_possible_method(method)
+      define_method(method, &block)
+    end
+  end
+
+  class Class
+    def class_attribute(*attrs)
+      attrs.each do |name|
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def self.#{name}() nil end
+          def self.#{name}?() !!#{name} end
+
+          def self.#{name}=(val)
+            singleton_class.class_eval do
+              remove_possible_method(:#{name})
+              define_method(:#{name}) { val }
+            end
+
+            if singleton_class?
+              class_eval do
+                remove_possible_method(:#{name})
+                def #{name}
+                  defined?(@#{name}) ? @#{name} : singleton_class.#{name}
+                end
+              end
+            end
+            val
+          end
+        RUBY
+
+      end
+    end
+
+    private
+    def singleton_class?
+      ancestors.first != self
+    end
+  end
+end

--- a/spec/parametric_spec.rb
+++ b/spec/parametric_spec.rb
@@ -138,6 +138,12 @@ describe Parametric do
       it_should_behave_like 'a configurable params object'
     end
 
+    describe 'subclassing' do
+      let(:subclass){ Class.new(klass) }
+      let(:subject){ subclass.new(foo: 'bar', per_page: 20, status: 'four') }
+      it_should_behave_like 'a configurable params object'
+    end
+
     describe '#available_params' do
       let(:subject) { klass.new(foo: 'bar', name: 'lala', per_page: 20, status: 'four', emails: 'one@email.com,two@email.com') }
 


### PR DESCRIPTION
Putting this here for discussion.
## What

A class' param definitions are inherited to its subclasses. Subclasses can add or modify inherited params.

``` ruby
class A
  include Parametric::Params
  param :title, 'The title'
end

class B < A
  param :age, 'The age'
end

a = A.new(title: 'An instance', age: 20)
a.params # {title: 'An instance'}

b = B.new(title: 'Another instance', age: 20)
b.params # {title: 'Another instance', age: 20}
```
## Why

So I can for example have a base `ProductParams` definition and the `CreateProductParams`, `UpdateProductParams` subclasses that may or may not add to the base definition.
## Discuss

This PR tries to use ActiveSupport's `class_attribute`, if present. Otherwise it monkey-patches `Class` to add its own version of that utility method. I would really prefer a way of doing this that didn't require monkey patching. Maybe _refinements_?
