### PR TITLE
:nullable option allows missing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ search = OrdersSearch.new
 search.params[:status] # => ['closed']
 ```
 
+### :nullable fields
+
+In same cases you won't want Parametric to provide nil or empty keys for attributes missing from the input. For example when missing keys has special meaning in your application.
+
+In those cases you can add the `:nullable` option to said param definitions:
+
+```ruby
+class OrdersSearch
+  include Parametric::Params
+  param :query, 'Search query. optional', nullable: true
+  param :tags, 'Tags', multiple: true
+end
+
+search = OrdersSearch.new({})
+search.params # {tags: []}
+```
+
 ## `available_params`
 
 `#available_params` returns the subset of keys that were populated (including defaults). Useful for building query strings.

--- a/lib/parametric/params.rb
+++ b/lib/parametric/params.rb
@@ -50,7 +50,7 @@ module Parametric
         policy = policy.wrap(Policies::MatchPolicy)    if options[:match]
         policy = policy.wrap(Policies::DefaultPolicy)  if options.has_key?(:default)
         policy = policy.wrap(Policies::SinglePolicy)   unless options[:multiple]
-        memo[key] = policy.value
+        memo[key] = policy.value unless options[:nullable] && !raw_params.has_key?(key)
       end
     end
 

--- a/spec/parametric_spec.rb
+++ b/spec/parametric_spec.rb
@@ -89,6 +89,10 @@ describe Parametric do
     it 'does not accept single option if not in declared options' do
       klass.new(country: 'USA').params[:country].should be_nil
     end
+
+    it 'does not include parameters marked as :nullable' do
+      klass.new.params.has_key?(:nullable).should be_false
+    end
   end
 
   describe 'TypedParams' do
@@ -103,6 +107,7 @@ describe Parametric do
         string :country, 'country', options: ['UK', 'CL', 'JPN']
         string :email, 'email', match: /\w+@\w+\.\w+/
         array :emails, 'emails', match: /\w+@\w+\.\w+/, default: 'default@email.com'
+        param :nullable, 'nullable param', nullable: true
       end
     end
 
@@ -124,6 +129,7 @@ describe Parametric do
         param :email, 'email', match: /\w+@\w+\.\w+/
         param :emails, 'emails', match: /\w+@\w+\.\w+/, multiple: true, default: 'default@email.com'
         param :available, 'available', default: true
+        param :nullable, 'nullable param', nullable: true
       end
     end
 


### PR DESCRIPTION
## What

`:nullable` option for cases where you don't want Parametric to fill in missing keys for you.

See changes to the Readme for explanation.
