### PR TITLE
Structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,128 @@ results.errors["$.Weight"] # => ["is required and value must be present"]
 
 NOTES: dynamically expanded field names are not included in `Schema#structure` metadata, and they are only processes if fields with the given expressions are present in the payload. This means that validations applied to those fields only run if keys are present in the first place.
 
+## Structs
+
+Structs turn schema definitions into objects graphs with attribute readers.
+
+Add optional `Parametrict::Struct` module to define struct-like objects with schema definitions.
+
+```ruby
+require 'parametric/struct'
+
+class User
+  include Parametric::Struct
+
+  schema do
+    field(:name).type(:string).present
+    field(:friends).type(:array).schema do
+      field(:name).type(:string).present
+      field(:age).type(:integer)
+    end
+  end
+end
+```
+
+`User` objects can be instantiated with hash data, which will be coerced and validated as per the schema definition.
+
+```ruby
+user = User.new(
+  name: 'Joe',
+  friends: [
+    {name: 'Jane', age: 40},
+    {name: 'John', age: 30},
+  ]
+)
+
+# properties
+user.name # => 'Joe'
+user.friends.first.name # => 'Jane'
+user.friends.last.age # => 30
+```
+
+### Errors
+
+Both the top-level and nested instances contain error information:
+
+```ruby
+user = User.new(
+  name: '', # invalid
+  friends: [
+    # friend name also invalid
+    {name: '', age: 40},
+  ]
+)
+
+user.valid? # false
+user.errors['$.name'] # => "is required and must be present"
+user.errors['$.friends[0].name'] # => "is required and must be present"
+
+# also access error in nested instances directly
+user.friends.first.valid? # false
+user.friends.first.errors['$.name'] # "is required and must be valid"
+```
+
+### Nested structs
+
+You can also pass separate struct classes in a nested schema definition.
+
+```ruby
+class Friend
+  include Parametric::Struct
+
+  schema do
+    field(:name).type(:string).present
+    field(:age).type(:integer)
+  end
+end
+
+class User
+  include Parametric::Struct
+
+  schema do
+    field(:name).type(:string).present
+    # here we use the Friend class
+    field(:friends).type(:array).schema Friend
+  end
+end
+```
+
+### Inheritance
+
+Struct subclasses can add to inherited schemas, or override fields defined in the parent.
+
+```ruby
+class AdminUser < User
+  # inherits User schema, and can add stuff to its own schema
+  schema do
+    field(:permissions).type(:array)
+  end
+end
+```
+
+### #to_h
+
+`Struct#to_h` returns the ouput hash, with values coerced and any defaults populated.
+
+```ruby
+class User
+  include Parametrict::Struct
+  schema do
+    field(:name).type(:string)
+    field(:age).type(:integer).default(30)
+  end
+end
+
+user = User.new(name: "Joe")
+user.to_h # {name: "Joe", age: 30}
+```
+
+### Struct equality
+
+`Parametric::Struct` implements `#==()` to compare two structs Hash representation (same as `struct1.to_h.eql?(struct2.to_h)`.
+
+Users can override `#==()` in their own classes to do whatever they need.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -41,6 +41,11 @@ module Parametric
 
         new_schema = Parametric::Schema.new(options, &block)
         @schema = @schema.merge(new_schema)
+        after_define_schema(@schema)
+      end
+
+      def after_define_schema(sc)
+        # noop hook
       end
     end
   end

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -40,7 +40,7 @@ module Parametric
     def schema(sc = nil, &block)
       sc = (sc ? sc : Schema.new(&block))
       meta schema: sc
-      policy sc
+      policy sc.schema
     end
 
     def visit(meta_key = nil, &visitor)

--- a/lib/parametric/schema.rb
+++ b/lib/parametric/schema.rb
@@ -14,6 +14,10 @@ module Parametric
       @expansions = {}
     end
 
+    def schema
+      self
+    end
+
     def fields
       apply!
       @fields

--- a/lib/parametric/struct.rb
+++ b/lib/parametric/struct.rb
@@ -20,8 +20,9 @@ module Parametric
       _results.errors
     end
 
+    # returns a shallow copy.
     def to_h
-      _results.output
+      _results.output.clone
     end
 
     def ==(other)

--- a/lib/parametric/struct.rb
+++ b/lib/parametric/struct.rb
@@ -1,0 +1,92 @@
+module Parametric
+  module Struct
+    def self.included(base)
+      base.extend ClassMethods
+      base.schema = Parametric::Schema.new
+    end
+
+    def initialize(attrs = {})
+      @_results = self.class.schema.resolve(attrs)
+      @_graph = build(@_results.output)
+    end
+
+    def valid?
+      !_results.errors.any?
+    end
+
+    def errors
+      _results.errors
+    end
+
+    def to_h
+      _results.output
+    end
+
+    private
+    attr_reader :_graph, :_results
+
+    def build(attrs)
+      attrs.each_with_object({}) do |(k, v), obj|
+        obj[k] = wrap(k, v)
+      end
+    end
+
+    def wrap(key, value)
+      field = self.class.schema.fields[key]
+      return value unless field
+
+      case value
+      when Hash
+        # find constructor for field
+        cons = field.meta_data[:_of]
+        cons ? cons.new(value) : value.freeze
+      when Array
+        value.map{|v| wrap(key, v) }.freeze
+      else
+        value.freeze
+      end
+    end
+
+    module ClassMethods
+      def schema=(sc)
+        @schema = sc
+      end
+
+      def schema
+        @schema ||= Parametric::Schema.new
+      end
+
+      def inherited(subclass)
+        subclass.schema = schema.merge(Parametric::Schema.new)
+      end
+
+      def property(key, type = nil, of: nil, &block)
+        default = case type
+                  when :array
+                    []
+                  when :object
+                    {}
+                  else
+                    nil
+                  end
+
+        define_method key do
+          _graph[key]
+        end
+
+        if block_given?
+          of = Class.new do
+            include Parametric::Struct
+            instance_exec &block
+          end
+        end
+
+        schema.field(key).meta(_of: of).tap do |f|
+          f.type(type) if type
+          f.schema(of.schema) if of
+          f.default(default) if default
+        end
+      end
+    end
+  end
+end

--- a/lib/parametric/struct.rb
+++ b/lib/parametric/struct.rb
@@ -24,6 +24,10 @@ module Parametric
       _results.output
     end
 
+    def ==(other)
+      other.respond_to?(:to_h) && other.to_h.eql?(to_h)
+    end
+
     private
     attr_reader :_graph, :_results
 

--- a/lib/parametric/struct.rb
+++ b/lib/parametric/struct.rb
@@ -28,6 +28,10 @@ module Parametric
       other.respond_to?(:to_h) && other.to_h.eql?(to_h)
     end
 
+    def merge(attrs = {})
+      self.class.new(to_h.merge(attrs))
+    end
+
     private
     attr_reader :_graph, :_results
 

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -186,4 +186,54 @@ describe Parametric::Struct do
     expect(instance.email).to eq 'email@me.com'
     expect(instance.friends.size).to eq 2
   end
+
+  it "implements deep struct equality" do
+    klass = Class.new do
+      include Parametric::Struct
+
+      schema do
+        field(:title).type(:string).present
+        field(:friends).type(:array).schema do
+          field(:age).type(:integer)
+        end
+      end
+    end
+
+    s1 = klass.new({
+      title: 'foo',
+      friends: [
+        {age: 10},
+        {age: 39},
+      ]
+    })
+
+
+    s2 = klass.new({
+      title: 'foo',
+      friends: [
+        {age: 10},
+        {age: 39},
+      ]
+    })
+
+    s3 = klass.new({
+      title: 'foo',
+      friends: [
+        {age: 11},
+        {age: 39},
+      ]
+    })
+
+    s4 = klass.new({
+      title: 'bar',
+      friends: [
+        {age: 10},
+        {age: 39},
+      ]
+    })
+
+    expect(s1 == s2).to be true
+    expect(s1 == s3).to be false
+    expect(s1 == s4).to be false
+  end
 end

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+require 'parametric/struct'
+
+describe Parametric::Struct do
+  it "works" do
+    friend_class = Class.new do
+      include Parametric::Struct
+
+      property(:name, :string).present
+      property :age, :integer
+    end
+
+    klass = Class.new do
+      include Parametric::Struct
+
+      property(:title, :string).present
+      property :friends, :array, of: friend_class
+    end
+
+    new_instance = klass.new
+    expect(new_instance.title).to eq ''
+    expect(new_instance.friends).to eq []
+    expect(new_instance.valid?).to be false
+    expect(new_instance.errors['$.title']).not_to be_nil
+
+    instance = klass.new({
+      title: 'foo',
+      friends: [
+        {name: 'Ismael', age: 40},
+        {name: 'Joe', age: 39},
+      ]
+    })
+
+    expect(instance.title).to eq 'foo'
+    expect(instance.friends.size).to eq 2
+    expect(instance.friends.first.name).to eq 'Ismael'
+    expect(instance.friends.first).to be_a friend_class
+  end
+
+  it "is inmutable by default" do
+    klass = Class.new do
+      include Parametric::Struct
+
+      property(:title, :string).present
+      property :friends, :array
+      property :friend, :object
+    end
+
+    instance = klass.new
+    expect {
+      instance.title = "foo"
+    }.to raise_error NoMethodError
+
+    expect {
+      instance.friends << 1
+    }.to raise_error RuntimeError
+  end
+
+  it "works with anonymous nested schemas" do
+    klass = Class.new do
+      include Parametric::Struct
+
+      property(:title, :string).present
+      property :friends, :array do
+        property :age, :integer
+      end
+    end
+
+    instance = klass.new({
+      title: 'foo',
+      friends: [
+        {age: 10},
+        {age: 39},
+      ]
+    })
+
+    expect(instance.title).to eq 'foo'
+    expect(instance.friends.size).to eq 2
+    expect(instance.friends.first.age).to eq 10
+  end
+
+  it "#to_h" do
+    klass = Class.new do
+      include Parametric::Struct
+
+      property(:title, :string).present
+      property :friends, :array do
+        property :name, :string
+        property(:age, :integer).default(20)
+      end
+    end
+
+    instance = klass.new({
+      title: 'foo',
+      friends: [
+        {name: 'Jane'},
+        {name: 'Joe', age: '39'},
+      ]
+    })
+
+    expect(instance.to_h).to eq({
+      title: 'foo',
+      friends: [
+        {name: 'Jane', age: 20},
+        {name: 'Joe', age: 39},
+      ]
+    })
+
+    new_instance = klass.new(instance.to_h)
+    expect(new_instance.title).to eq 'foo'
+  end
+end

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -242,7 +242,7 @@ describe Parametric::Struct do
     expect(s1 == s4).to be false
   end
 
-  it "#update returns a new instance" do
+  it "#merge returns a new instance" do
     klass = Class.new do
       include Parametric::Struct
 

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -152,6 +152,11 @@ describe Parametric::Struct do
 
     new_instance = klass.new(instance.to_h)
     expect(new_instance.title).to eq 'foo'
+
+    # it returns a copy so we can't break things!
+    data = new_instance.to_h
+    data[:title] = 'nope'
+    expect(new_instance.to_h[:title]).to eq 'foo'
   end
 
   it "works with inheritance" do

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -39,6 +39,18 @@ describe Parametric::Struct do
     expect(instance.friends.size).to eq 2
     expect(instance.friends.first.name).to eq 'Ismael'
     expect(instance.friends.first).to be_a friend_class
+
+    invalid_instance = klass.new({
+      friends: [
+        {name: 'Ismael', age: 40},
+        {age: 39},
+      ]
+    })
+
+    expect(invalid_instance.valid?).to be false
+    expect(invalid_instance.errors['$.title']).not_to be_nil
+    expect(invalid_instance.errors['$.friends[1].name']).not_to be_nil
+    expect(invalid_instance.friends[1].errors['$.name']).not_to be_nil
   end
 
   it "is inmutable by default" do

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -99,6 +99,28 @@ describe Parametric::Struct do
     expect(instance.friends.first.age).to eq 10
   end
 
+  it "wraps regular schemas in structs" do
+    friend_schema = Parametric::Schema.new do
+      field(:name)
+    end
+
+    klass = Class.new do
+      include Parametric::Struct
+
+      schema do
+        field(:title).type(:string).present
+        field(:friends).type(:array).schema friend_schema
+      end
+    end
+
+    instance = klass.new({
+      title: 'foo',
+      friends: [{name: 'Ismael'}]
+    })
+
+    expect(instance.friends.first.name).to eq 'Ismael'
+  end
+
   it "#to_h" do
     klass = Class.new do
       include Parametric::Struct

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -236,4 +236,37 @@ describe Parametric::Struct do
     expect(s1 == s3).to be false
     expect(s1 == s4).to be false
   end
+
+  it "#update returns a new instance" do
+    klass = Class.new do
+      include Parametric::Struct
+
+      schema do
+        field(:title).type(:string).present
+        field(:desc)
+        field(:friends).type(:array).schema do
+          field(:name).type(:string)
+        end
+      end
+    end
+
+    original = klass.new(
+      title: 'foo',
+      desc: 'no change',
+      friends: [{name: 'joe'}]
+    )
+
+    copy = original.merge(
+      title: 'bar',
+      friends: [{name: 'jane'}]
+    )
+
+    expect(original.title).to eq 'foo'
+    expect(original.desc).to eq 'no change'
+    expect(original.friends.first.name).to eq 'joe'
+
+    expect(copy.title).to eq 'bar'
+    expect(copy.desc).to eq 'no change'
+    expect(copy.friends.first.name).to eq 'jane'
+  end
 end


### PR DESCRIPTION
## What

Add optional `Parametrict::Struct` module to define struct-like objects with schema definitions.

```ruby
require 'parametric/struct'

class User
  include Parametric::Struct

  schema do
    field(:name).type(:string).present
    field(:friends).type(:array).schema do
      field(:name).type(:string).present
      field(:age).type(:integer)
    end
  end
end
```

`User` objects can be instantiated with hash data, which will be coerced and validated as per the schema definition.

```ruby
user = User.new(
  name: 'Joe',
  friends: [
    {name: 'Jane', age: 40},
    {name: 'John', age: 30},
  ]
)

# properties
user.name # => 'Joe'
user.friends.first.name # => 'Jane'
user.friends.last.age # => 30
```

### Errors

Both the top-level and nested instances contain error information:

```ruby
user = User.new(
  name: '', # invalid
  friends: [
    # friend name also invalid
    {name: '', age: 40},
  ]
)

user.valid? # false
user.errors['$.name'] # => "is required and must be present"
user.errors['$.friends[0].name'] # => "is required and must be present"

# also access error in nested instances directly
user.friends.first.valid? # false
user.friends.first.errors['$.name'] # "is required and must be valid"
```

### Nested structs

You can also pass separate struct classes in a nested schema definition.

```ruby
class Friend
  include Parametric::Struct

  schema do
    field(:name).type(:string).present
    field(:age).type(:integer)
  end
end

class User
  include Parametric::Struct

  schema do
    field(:name).type(:string).present
    # here we use the Friend class
    field(:friends).type(:array).schema Friend
  end
end
```

### Inheritance

Struct subclasses can add to inherited schemas, or override fields defined in the parent.

```ruby
class AdminUser < User
  # inherits User schema, and can add stuff to its own schema
  schema do
    field(:permissions).type(:array)
  end
end
```

### #to_h

`Struct#to_h` returns the ouput hash, with values coerced and any defaults populated.

```ruby
class User
  include Parametrict::Struct
  schema do
    field(:name).type(:string)
    field(:age).type(:integer).default(30)
  end
end

user = User.new(name: "Joe")
user.to_h # {name: "Joe", age: 30}
```

### Struct equality

`Parametric::Struct` implements `#==()` to compare two structs Hash representation (same as `struct1.to_h.eql?(struct2.to_h)`.

Users can override `#==()` in their own classes to do whatever they need.
