### PR TITLE
Schema#expand expands fields on the fly with regexes

### DIFF
--- a/spec/expand_spec.rb
+++ b/spec/expand_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Parametric::Schema do
+  it "expands fields dynamically" do
+    schema = described_class.new do
+      field(:title).type(:string).present
+      expand(/^attr_(.+)/) do |match|
+        field(match[1]).type(:string)
+      end
+      expand(/^validate_(.+)/) do |match|
+        field(match[1]).type(:string).present
+      end
+    end
+
+    out = schema.resolve({
+      title: "foo",
+      :"attr_Attribute 1" => "attr 1",
+      :"attr_Attribute 2" => "attr 2",
+      :"validate_valid_attr" => "valid",
+      :"validate_invalid_attr" => "",
+    })
+
+    expect(out.output[:title]).to eq 'foo'
+    expect(out.output[:"Attribute 1"]).to eq 'attr 1'
+    expect(out.output[:"Attribute 2"]).to eq 'attr 2'
+
+    expect(out.errors['$.invalid_attr']).to eq ['is required and value must be present']
+  end
+end


### PR DESCRIPTION
## Expanding fields dynamically

Sometimes you don't know the exact field names but you want to allow arbitrary fields depending on a given pattern.

```ruby
# with this payload:
# {
#   title: "A title",
#   :"custom_attr_Color" => "red",
#   :"custom_attr_Material" => "leather"
# }

schema = Parametric::Schema.new do
  field(:title).type(:string).present
  # here we allow any field starting with /^custom_attr/
  # this yields a MatchData object to the block
  # where you can define a Field and validations on the fly
  # https://ruby-doc.org/core-2.2.0/MatchData.html
  expand(/^custom_attr_(.+)/) do |match|
    field(match[1]).type(:string).present
  end
end

results = schema.resolve({
  title: "A title",
  :"custom_attr_Color" => "red",
  :"custom_attr_Material" => "leather",
  :"custom_attr_Weight" => "",
})

results.ouput[:Color] # => "red"
results.ouput[:Material] # => "leather"
results.errors["$.Weight"] # => ["is required and value must be present"]
```

NOTES: dynamically expanded field names are not included in `Schema#structure` metadata, and they are only processes if fields with the given expressions are present in the payload. This means that validations applied to those fields only run if keys are present in the first place.
