### PR TITLE
Multiple schema forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,34 @@ class CreateUserForm
 end
 ```
 
+## Multiple schema definitions
+
+Form objects can optionally define more than one schema by giving them names:
+
+```ruby
+class UpdateUserForm
+  include Parametric::DSL
+
+  # a schema named :query
+  # for example for query parameters
+  schema(:query) do
+    field(:user_id).type(:integer).present
+  end
+
+  # a schema for PUT body parameters
+  schema(:payload) do
+    field(:name).present
+    field(:age).present
+  end
+end
+```
+
+Named schemas are inherited and can be extended and given options in the same way as the nameless version.
+
+Named schemas can be retrieved by name, ie. `UpdateUserForm.schema(:query)`.
+
+If no name given, `.schema` uses `:schema` as default schema name.
+
 ## Expanding fields dynamically
 
 Sometimes you don't know the exact field names but you want to allow arbitrary fields depending on a given pattern.

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -22,26 +22,39 @@ module Parametric
     #
     #   foo.params # => {title: "A title", age: 20}
     #
+    DEFAULT_SCHEMA_NAME = :schema
+
     def self.included(base)
       base.extend(ClassMethods)
-      base.schema = Parametric::Schema.new
+      base.schemas = {DEFAULT_SCHEMA_NAME => Parametric::Schema.new}
     end
 
     module ClassMethods
       def schema=(sc)
-        @schema = sc
+        @schemas[DEFAULT_SCHEMA_NAME] = sc
+      end
+
+      def schemas=(sc)
+        @schemas = sc
       end
 
       def inherited(subclass)
-        subclass.schema = @schema.merge(Parametric::Schema.new)
+        subclass.schemas = @schemas.each_with_object({}) do |(key, sc), hash|
+          hash[key] = sc.merge(Parametric::Schema.new)
+        end
       end
 
       def schema(options = {}, &block)
-        return @schema unless options.any? || block_given?
+        key = DEFAULT_SCHEMA_NAME
+        current_schema = @schemas[key]
+        unless options.any? || block_given?
+          raise ArgumentError, "No schema with name #{key}" unless current_schema
+          return current_schema
+        end
 
         new_schema = Parametric::Schema.new(options, &block)
-        @schema = @schema.merge(new_schema)
-        after_define_schema(@schema)
+        @schemas[key] = current_schema ? current_schema.merge(new_schema) : new_schema
+        after_define_schema(@schemas[key])
       end
 
       def after_define_schema(sc)

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -47,7 +47,7 @@ module Parametric
       def schema(*args, &block)
         options = args.last.is_a?(Hash) ? args.last : {}
         key = args.first.is_a?(Symbol) ? args.first : DEFAULT_SCHEMA_NAME
-        current_schema = @schemas[key]
+        current_schema = @schemas.fetch(key) { Parametric::Schema.new }
         return current_schema unless options.any? || block_given?
 
         new_schema = Parametric::Schema.new(options, &block)

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -44,8 +44,9 @@ module Parametric
         end
       end
 
-      def schema(options = {}, &block)
-        key = DEFAULT_SCHEMA_NAME
+      def schema(*args, &block)
+        options = args.last.is_a?(Hash) ? args.last : {}
+        key = args.first.is_a?(Symbol) ? args.first : DEFAULT_SCHEMA_NAME
         current_schema = @schemas[key]
         unless options.any? || block_given?
           raise ArgumentError, "No schema with name #{key}" unless current_schema

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -48,10 +48,7 @@ module Parametric
         options = args.last.is_a?(Hash) ? args.last : {}
         key = args.first.is_a?(Symbol) ? args.first : DEFAULT_SCHEMA_NAME
         current_schema = @schemas[key]
-        unless options.any? || block_given?
-          raise ArgumentError, "No schema with name #{key}" unless current_schema
-          return current_schema
-        end
+        return current_schema unless options.any? || block_given?
 
         new_schema = Parametric::Schema.new(options, &block)
         @schemas[key] = current_schema ? current_schema.merge(new_schema) : new_schema


### PR DESCRIPTION
## Multiple schema definitions

Form objects can optionally define more than one schema by giving them names:

```ruby
class UpdateUserForm
  include Parametric::DSL

  # a schema named :query
  # for example for query parameters
  schema(:query) do
    field(:user_id).type(:integer).present
  end

  # a schema for PUT body parameters
  schema(:payload) do
    field(:name).present
    field(:age).present
  end
end
```

Named schemas are inherited and can be extended and given options in the same way as the nameless version.

Named schemas can be retrieved by name, ie. `UpdateUserForm.schema(:query)`.

If no name given, `.schema` uses `:schema` as default schema name.