### PR TITLE
Optionally pass schema to form instead of block

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,21 @@ class CreateUserForm
 end
 ```
 
+Form schemas can also be defined by passing another form or schema instance. This can be useful when building form classes in runtime.
+
+```ruby
+UserSchema = Parametric::Schema.new do
+  field(:name).type(:string).present
+  field(:age).type(:integer)
+end
+
+class CreateUserForm
+  include Parametric::DSL
+  # copy from UserSchema
+  schema UserSchema
+end
+```
+
 ### Form object inheritance
 
 Sub classes of classes using the DSL will inherit schemas defined on the parent class.

--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -48,9 +48,14 @@ module Parametric
         options = args.last.is_a?(Hash) ? args.last : {}
         key = args.first.is_a?(Symbol) ? args.first : DEFAULT_SCHEMA_NAME
         current_schema = @schemas.fetch(key) { Parametric::Schema.new }
-        return current_schema unless options.any? || block_given?
+        new_schema = if block_given? || options.any?
+          Parametric::Schema.new(options, &block)
+        elsif args.first.respond_to?(:schema)
+          args.first
+        end
 
-        new_schema = Parametric::Schema.new(options, &block)
+        return current_schema unless new_schema
+
         @schemas[key] = current_schema ? current_schema.merge(new_schema) : new_schema
         after_define_schema(@schemas[key])
       end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -156,5 +156,21 @@ describe "classes including DSL module" do
       expect(results.output).to eq({age: 20})
     end
   end
+
+  describe "passing other schema or form in definition" do
+    it 'applies schema' do
+      a = Parametric::Schema.new do
+        field(:name).policy(:string)
+        field(:age).policy(:integer).default(40)
+      end
+      b = Class.new do
+        include Parametric::DSL
+        schema a
+      end
+
+      results = b.schema.resolve(name: 'Neil')
+      expect(results.output).to eq({name: 'Neil', age: 40})
+    end
+  end
 end
 


### PR DESCRIPTION
Form schemas can also be defined by passing another form or schema instance. This can be useful when building form classes in runtime.

 ```ruby
UserSchema = Parametric::Schema.new do
  field(:name).type(:string).present
  field(:age).type(:integer)
end

class CreateUserForm
  include Parametric::DSL
  # copy from UserSchema
  schema UserSchema
end
```