### PR TITLE
Struct.new!

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,20 @@ user.friends.first.valid? # false
 user.friends.first.errors['$.name'] # "is required and must be valid"
 ```
 
+### .new!(hash)
+
+Instantiating structs with `.new!(hash)` will raise a `Parametric::InvalidStructError` exception if the data is validations fail. It will return the struct instance otherwise.
+
+`Parametric::InvalidStructError` includes an `#errors` property to inspect the errors raised.
+
+```ruby
+begin
+  user = User.new!(name: '')
+rescue Parametric::InvalidStructError => e
+  e.errors['$.name'] # "is required and must be present"
+end
+```
+
 ### Nested structs
 
 You can also pass separate struct classes in a nested schema definition.

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -274,4 +274,25 @@ describe Parametric::Struct do
     expect(copy.desc).to eq 'no change'
     expect(copy.friends.first.name).to eq 'jane'
   end
+
+  describe '.new!' do
+    it 'raises a useful exception if invalid data' do
+      klass = Class.new do
+        include Parametric::Struct
+
+        schema do
+          field(:title).type(:string).present
+        end
+      end
+
+      begin
+        klass.new!(title: '')
+      rescue Parametric::InvalidStructError => e
+        expect(e.errors['$.title']).not_to be nil
+      end
+
+      valid = klass.new!(title: 'foo')
+      expect(valid.title).to eq 'foo'
+    end
+  end
 end


### PR DESCRIPTION
## What

This PR introduces `Struct.new!(hash)`.

Instantiating structs with `.new!(hash)` will raise a `Parametric::InvalidStructError` exception if the data is validations fail. It will return the struct instance otherwise.

`Parametric::InvalidStructError` includes an `#errors` property to inspect the errors raised.

```ruby
begin
  user = User.new!(name: '')
rescue Parametric::InvalidStructError => e
  e.errors['$.name'] # "is required and must be present"
end
```

## Why

I keep coming back to this pattern (raise if invalid) in different apps using Parametric.
