### PR TITLE
Allow building custom struct sub-classes

### DIFF
--- a/lib/parametric/dsl.rb
+++ b/lib/parametric/dsl.rb
@@ -57,10 +57,10 @@ module Parametric
         return current_schema unless new_schema
 
         @schemas[key] = current_schema ? current_schema.merge(new_schema) : new_schema
-        after_define_schema(@schemas[key])
+        parametric_after_define_schema(@schemas[key])
       end
 
-      def after_define_schema(sc)
+      def parametric_after_define_schema(sc)
         # noop hook
       end
     end

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -99,6 +99,32 @@ describe Parametric::Struct do
     expect(instance.friends.first.age).to eq 10
   end
 
+  it 'wraps nested schemas in custom class' do
+    klass = Class.new do
+      include Parametric::Struct
+
+      def self.parametric_build_class_for_child(key, child_schema)
+        Class.new do
+          include Parametric::Struct
+          schema child_schema
+          def salutation
+            "my age is #{age}"
+          end
+        end
+      end
+
+      schema do
+        field(:name).type(:string).present
+        field(:friends).type(:array).schema do
+          field(:age).type(:integer)
+        end
+      end
+    end
+
+    user = klass.new(name: 'Ismael', friends: [{age: 43}])
+    expect(user.friends.first.salutation).to eq 'my age is 43'
+  end
+
   it "wraps regular schemas in structs" do
     friend_schema = Parametric::Schema.new do
       field(:name)


### PR DESCRIPTION
## What

Add `Struct.parametric_build_class_for_child` hook.

It builds anonymous class for nested structs.
So users can override this hook and build classes however they see fit.

Also renamed `.after_define_schema` to `.parametric_after_define_schema`, for consistency.

## Why

So we can write custom struct wrappers that wrap nested objects in our own classes (use case: ActiveModel wrapper for parametric schemas).
