### PR TITLE
:declared_no_default policy skips default if key not present in input

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,19 @@ field(:name).declared.present
 ```
 
 The example above will check that the value is not empty, but only if the key exists. If the key doesn't exist no validations will run.
+Note that any defaults will still be returned.
+
+```ruby
+field(:name).declared.present.default('return this')
+```
+
+### :declared_no_default
+
+Like `:declared`, it stops the policy chain if a key is not in input, but it also skips any default value.
+
+```ruby
+field(:name).policy(:declared_no_default).present
+```
 
 ### :gt
 

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -96,7 +96,7 @@ module Parametric
     end
 
     def has_default?
-      !!default_block
+      !!default_block && !meta_data[:skip_default]
     end
 
     def lookup(key, args)

--- a/lib/parametric/policies.rb
+++ b/lib/parametric/policies.rb
@@ -44,6 +44,16 @@ module Parametric
     end
   end
 
+  Parametric.policy :declared_no_default do
+    eligible do |value, key, payload|
+      payload.key? key
+    end
+
+    meta_data do
+      {skip_default: true}
+    end
+  end
+
   Parametric.policy :required do
     message do |*|
       "is required"

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -266,6 +266,24 @@ describe Parametric::Field do
         expect(r.value).to eq nil
       end
     end
+
+    it "returns default" do
+      resolve(subject.policy(:declared).default('aa'), foo: "").tap do |r|
+        expect(r.eligible?).to be true
+        no_errors
+        expect(r.value).to eq 'aa'
+      end
+    end
+  end
+
+  describe ':declared_no_default' do
+    it "does not return default" do
+      resolve(subject.policy(:declared_no_default).default('aa'), lala: "").tap do |r|
+        expect(r.eligible?).to be false
+        no_errors
+        expect(r.value).to eq nil
+      end
+    end
   end
 
   describe ":noop policy" do


### PR DESCRIPTION
## :declared_no_default policy

Like `:declared`, it stops the policy chain if a key is not in input, but it also skips any default value.

```ruby
field(:name).policy(:declared_no_default).present
```

## Use case

We have a schema with defaults and validations:

```ruby
schema = Parametric::Schema.new do
  field(:name).type(:string).present
  field(:price).type(:integer).default(0)
end

schema.resolve(name: 'iPhone').output # {name: 'iPhone', price: 0}, price default is added
```

In some cases we might want to reuse the schema to run partial updates on a resource (ie. only update keys that are present), which means we only want to validate keys that are present, and NOT fill in default values for keys that are no in the input.

```ruby
update_schema = schema.clone.policy(:declared_no_default)
update_schema.resolve(name: 'iPhone').output # {name: 'iPhone'}, price default is omitted
```
