### PR TITLE
Optionally yield schema to definition block and preserve block context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ results.errors # => {"$.friends[0].name" => "is required"}
 You can optionally use an existing schema instance as a nested schema:
 
 ```ruby
-friends_schema = Parametric::Schema.new do
+FRIENDS_SCHEMA = Parametric::Schema.new do
   field(:friends).type(:array).schema do
     field(:name).type(:string).required
     field(:email).policy(:email)
@@ -109,10 +109,24 @@ person_schema = Parametric::Schema.new do
   field(:name).type(:string).required
   field(:age).type(:integer)
   # Nest friends_schema
-  field(:friends).type(:array).schema(friends_schema)
+  field(:friends).type(:array).schema(FRIENDS_SCHEMA)
 end
 ```
 
+Note that _person_schema_'s definition has access to `FRIENDS_SCHEMA` because it's a constant.
+Definition blocks are run in the context of the defining schema instance by default.
+
+To preserve the original block's context, declare two arguments in your block, the defining schema `sc` and options has.
+
+```ruby
+person_schema = Parametric::Schema.new do |sc, options|
+  # this block now preserves its context. Call `sc.field` to add fields to the current schema.
+  sc.field(:name).type(:string).required
+  sc.field(:age).type(:integer)
+  # We now have access to local variables
+  sc.field(:friends).type(:array).schema(friends_schema)
+end
+```
 ## Built-in policies
 
 Type coercions (the `type` method) and validations (the `validate` method) are all _policies_.

--- a/lib/parametric/schema.rb
+++ b/lib/parametric/schema.rb
@@ -182,7 +182,11 @@ module Parametric
     def apply!
       return if @applied
       definitions.each do |d|
-        self.instance_exec(options, &d)
+        if d.arity == 2 # pass schema instance and options, preserve block context
+          d.call(self, options)
+        else # run block in context of current instance
+          self.instance_exec(options, &d)
+        end
       end
       @applied = true
     end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -237,6 +237,20 @@ describe Parametric::Schema do
     end
   end
 
+  context 'yielding schema to definition, to preserve outer context' do
+    it 'yields schema instance and options to definition block, can access outer context' do
+      schema1 = described_class.new do
+        field(:name).type(:string)
+      end
+      schema2 = described_class.new do |sc, _opts|
+        sc.field(:user).schema schema1
+      end
+
+      out = schema2.resolve(user: { name: 'Joe' }).output
+      expect(out[:user][:name]).to eq 'Joe'
+    end
+  end
+
   describe "#ignore" do
     it "ignores fields" do
       s1 = described_class.new.ignore(:title, :status) do


### PR DESCRIPTION
## Problem

Definition blocks are run in the context of the defining schema instance by default.

The following works because `FRIENDS_SCHEMA` is a constant.

```ruby
person_schema = Parametric::Schema.new do
  field(:name).type(:string).required
  field(:age).type(:integer)
  # Nest friends_schema
  field(:friends).type(:array).schema(FRIENDS_SCHEMA)
end
```

Sometimes, however, we'll want to have access to local variables in a definition block.

## Solution

If a definition block declares 2 arguments, the defining schema instance will be yielded to it (the second argument is the options hash). The block preserves its context including access to local variables.

```ruby
person_schema = Parametric::Schema.new do |sc, options|
  # this block now preserves its context. Call `sc.field` to add fields to the current schema.
  sc.field(:name).type(:string).required
  sc.field(:age).type(:integer)
  # We now have access to local variables
  sc.field(:friends).type(:array).schema(friends_schema)
end
```