### PR TITLE
Schema#before_resolve and #after_resolve hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,102 @@ results.errors["$.Weight"] # => ["is required and value must be present"]
 
 NOTES: dynamically expanded field names are not included in `Schema#structure` metadata, and they are only processes if fields with the given expressions are present in the payload. This means that validations applied to those fields only run if keys are present in the first place.
 
+## Prepare blocks
+
+`Schema#prepare` can be used to register blocks to modify the entire input payload _before_ individual fields are validated and coerced.
+This can be useful when you need to pre-populate fields relative to other fields' values, or fetch extra data from other sources.
+
+```ruby
+# This example computes the value of the :slug field based on :name
+schema = Parametric::Schema.new do
+  # Note1: These blocks run before field validations, so :name might be blank or invalid at this point.
+  # Note2: Prepare blocks _must_ return a payload hash.
+  prepare do |payload, context|
+    payload.merge(
+      slug: payload[:name].to_s.downcase.gsub(/\s+/, '-')
+    )
+  end
+
+  # You still need to define the fields you want
+  field(:name).type(:string).present
+  field(:slug).type(:string).present
+end
+
+result = schema.resolve( name: 'Joe Bloggs' )
+result.output # => { name: 'Joe Bloggs', slug: 'joe-bloggs' }
+```
+
+Prepare blocks can be added to nested schemas, too:
+
+```ruby
+schema = Parametric::Schema.new do
+  field(:friends).type(:array).schema do
+    prepare do |friend_payload, context|
+      friend_payload.merge(title: "Mr/Ms #{payload[:name]}")
+    end
+
+    field(:name).type(:string)
+  end
+end
+```
+
+You can use inline blocks, but anything that responds to `#call(payload, context)` will work, too:
+
+```ruby
+class SlugMaker
+  def initialize(slug_field, from:)
+    @slug_field, @from = slug_field, from
+  end
+
+  def call(payload, context)
+    payload.merge(
+      @slug_field => payload[@from].to_s.downcase.gsub(/\s+/, '-')
+    )
+  end
+end
+
+schema = Parametric::Schema.new do
+  prepare SlugMaker.new(:slug, from: :name)
+
+  field(:name).type(:string)
+  field(:slug).type(:slug)
+end
+```
+
+The `context` argument can be used to custom validation errors in a prepare block.
+
+```ruby
+schema = Parametric::Schema.new do
+  prepare do |payload, context|
+    # validate that there's no duplicate friend names
+    friends = payload[:friends] || []
+    if friends.any? && friends.map{ |fr| fr[:name] }.uniq.size < friends.size
+      context.add_error 'friend names must be unique'
+    end
+
+    # don't forget to return the payload
+    payload
+  end
+
+  field(:friends).type(:array).schema do
+    field(:name).type(:string)
+  end
+end
+
+result = schema.resolve(
+  friends: [
+    {name: 'Joe Bloggs'},
+    {name: 'Joan Bloggs'},
+    {name: 'Joe Bloggs'}
+  ]
+)
+
+result.valid? # => false
+result.errors # => {'$' => ['friend names must be unique']}
+```
+
+In most cases you should be validating individual fields using field policies. Only validate in prepare blocks in cases you have dependencies between fields.
+
 ## Structs
 
 Structs turn schema definitions into objects graphs with attribute readers.

--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ Prepare blocks can be added to nested schemas, too:
 schema = Parametric::Schema.new do
   field(:friends).type(:array).schema do
     prepare do |friend_payload, context|
-      friend_payload.merge(title: "Mr/Ms #{payload[:name]}")
+      friend_payload.merge(title: "Mr/Ms #{friend_payload[:name]}")
     end
 
     field(:name).type(:string)
@@ -912,7 +912,7 @@ schema = Parametric::Schema.new do
 end
 ```
 
-The `context` argument can be used to custom validation errors in a prepare block.
+The `context` argument can be used to add custom validation errors in a prepare block.
 
 ```ruby
 schema = Parametric::Schema.new do

--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ end
 
 result = schema.resolve({ deposit: 1100, house_price: 1000 })
 result.valid? # false
+result.errors[:deposit] # ['cannot be greater than house price']
 result.output[:deposit] # 1100
 result.output[:house_price] # 1000
 result.output[:desc] # 'hello'

--- a/README.md
+++ b/README.md
@@ -884,6 +884,7 @@ schema = Parametric::Schema.new do
     end
 
     field(:name).type(:string)
+    field(:title).type(:string)
   end
 end
 ```

--- a/lib/parametric/context.rb
+++ b/lib/parametric/context.rb
@@ -28,6 +28,10 @@ module Parametric
       top.add_error(string_path, msg)
     end
 
+    def add_base_error(key, msg)
+      top.add_error(key, msg)
+    end
+
     def sub(key)
       self.class.new(path + [key], top)
     end

--- a/lib/parametric/context.rb
+++ b/lib/parametric/context.rb
@@ -46,5 +46,4 @@ module Parametric
       end.join
     end
   end
-
 end

--- a/spec/schema_lifecycle_hooks_spec.rb
+++ b/spec/schema_lifecycle_hooks_spec.rb
@@ -1,93 +1,95 @@
 require 'spec_helper'
 
 describe Parametric::Schema do
-  it 'passes payload through before_resolve block, if defined' do
-    schema = described_class.new do
-      before_resolve do |payload, _context|
-        payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
-        payload
-      end
-
-      field(:name).policy(:string).present
-      field(:slug).policy(:string).present
-      field(:variants).policy(:array).schema do
+  describe '#before_resolve' do
+    it 'passes payload through before_resolve block, if defined' do
+      schema = described_class.new do
         before_resolve do |payload, _context|
-          payload[:slug] = "v: #{payload[:name].to_s.downcase}"
+          payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
           payload
         end
+
         field(:name).policy(:string).present
-        field(:slug).type(:string).present
+        field(:slug).policy(:string).present
+        field(:variants).policy(:array).schema do
+          before_resolve do |payload, _context|
+            payload[:slug] = "v: #{payload[:name].to_s.downcase}"
+            payload
+          end
+          field(:name).policy(:string).present
+          field(:slug).type(:string).present
+        end
       end
+
+      result = schema.resolve({ name: 'A name', variants: [{ name: 'A variant' }] })
+      expect(result.valid?).to be true
+      expect(result.output[:slug]).to eq 'a-name'
+      expect(result.output[:variants].first[:slug]).to eq 'v: a variant'
     end
 
-    result = schema.resolve({ name: 'A name', variants: [{ name: 'A variant' }] })
-    expect(result.valid?).to be true
-    expect(result.output[:slug]).to eq 'a-name'
-    expect(result.output[:variants].first[:slug]).to eq 'v: a variant'
-  end
+    it 'collects errors added in before_resolve blocks' do
+      schema = described_class.new do
+        field(:variants).type(:array).schema do
+          before_resolve do |payload, context|
+            context.add_error 'nope!' if payload[:name] == 'with errors'
+            payload
+          end
+          field(:name).type(:string)
+        end
+      end
 
-  it 'collects errors added in before_resolve blocks' do
-    schema = described_class.new do
-      field(:variants).type(:array).schema do
-        before_resolve do |payload, context|
-          context.add_error 'nope!' if payload[:name] == 'with errors'
+      results = schema.resolve({ variants: [ {name: 'no errors'}, {name: 'with errors'}]})
+      expect(results.valid?).to be false
+      expect(results.errors['$.variants[1]']).to eq ['nope!']
+    end
+
+    it 'copies before_resolve hooks to merged schemas' do
+      schema1 = described_class.new do
+        before_resolve do |payload, _context|
+          payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
           payload
         end
-        field(:name).type(:string)
-      end
-    end
-
-    results = schema.resolve({ variants: [ {name: 'no errors'}, {name: 'with errors'}]})
-    expect(results.valid?).to be false
-    expect(results.errors['$.variants[1]']).to eq ['nope!']
-  end
-
-  it 'copies pre-resolvers to merged schemas' do
-    schema1 = described_class.new do
-      before_resolve do |payload, _context|
-        payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
-        payload
-      end
-      field(:name).present.type(:string)
-      field(:slug).present.type(:string)
-    end
-
-    schema2 = described_class.new do
-      before_resolve do |payload, _context|
-        payload[:slug] = "slug-#{payload[:slug]}" if payload[:slug]
-        payload
+        field(:name).present.type(:string)
+        field(:slug).present.type(:string)
       end
 
-      field(:age).type(:integer)
-    end
+      schema2 = described_class.new do
+        before_resolve do |payload, _context|
+          payload[:slug] = "slug-#{payload[:slug]}" if payload[:slug]
+          payload
+        end
 
-    schema3 = schema1.merge(schema2)
-
-    results = schema3.resolve({ name: 'Ismael Celis', age: 41 })
-    expect(results.output[:slug]).to eq 'slug-ismael-celis'
-  end
-
-  it 'works with any callable' do
-    slug_maker = Class.new do
-      def initialize(slug_field, from:)
-        @slug_field, @from = slug_field, from
+        field(:age).type(:integer)
       end
 
-      def call(payload, _context)
-        payload.merge(
-          @slug_field => payload[@from].to_s.downcase.gsub(/\s+/, '-')
-        )
+      schema3 = schema1.merge(schema2)
+
+      results = schema3.resolve({ name: 'Ismael Celis', age: 41 })
+      expect(results.output[:slug]).to eq 'slug-ismael-celis'
+    end
+
+    it 'works with any callable' do
+      slug_maker = Class.new do
+        def initialize(slug_field, from:)
+          @slug_field, @from = slug_field, from
+        end
+
+        def call(payload, _context)
+          payload.merge(
+            @slug_field => payload[@from].to_s.downcase.gsub(/\s+/, '-')
+          )
+        end
       end
+
+      schema = described_class.new do |sc, _opts|
+        sc.before_resolve slug_maker.new(:slug, from: :name)
+
+        sc.field(:name).type(:string)
+        sc.field(:slug).type(:string)
+      end
+
+      results = schema.resolve(name: 'Ismael Celis')
+      expect(results.output[:slug]).to eq 'ismael-celis'
     end
-
-    schema = described_class.new do |sc, _opts|
-      sc.before_resolve slug_maker.new(:slug, from: :name)
-
-      sc.field(:name).type(:string)
-      sc.field(:slug).type(:string)
-    end
-
-    results = schema.resolve(name: 'Ismael Celis')
-    expect(results.output[:slug]).to eq 'ismael-celis'
   end
 end

--- a/spec/schema_lifecycle_hooks_spec.rb
+++ b/spec/schema_lifecycle_hooks_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Parametric::Schema do
-  it 'passes payload through prepare block, if defined' do
+  it 'passes payload through before_resolve block, if defined' do
     schema = described_class.new do
-      prepare do |payload, _context|
+      before_resolve do |payload, _context|
         payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
         payload
       end
@@ -11,7 +11,7 @@ describe Parametric::Schema do
       field(:name).policy(:string).present
       field(:slug).policy(:string).present
       field(:variants).policy(:array).schema do
-        prepare do |payload, _context|
+        before_resolve do |payload, _context|
           payload[:slug] = "v: #{payload[:name].to_s.downcase}"
           payload
         end
@@ -26,10 +26,10 @@ describe Parametric::Schema do
     expect(result.output[:variants].first[:slug]).to eq 'v: a variant'
   end
 
-  it 'collects errors added in pre-resolvers' do
+  it 'collects errors added in before_resolve blocks' do
     schema = described_class.new do
       field(:variants).type(:array).schema do
-        prepare do |payload, context|
+        before_resolve do |payload, context|
           context.add_error 'nope!' if payload[:name] == 'with errors'
           payload
         end
@@ -44,7 +44,7 @@ describe Parametric::Schema do
 
   it 'copies pre-resolvers to merged schemas' do
     schema1 = described_class.new do
-      prepare do |payload, _context|
+      before_resolve do |payload, _context|
         payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
         payload
       end
@@ -53,7 +53,7 @@ describe Parametric::Schema do
     end
 
     schema2 = described_class.new do
-      prepare do |payload, _context|
+      before_resolve do |payload, _context|
         payload[:slug] = "slug-#{payload[:slug]}" if payload[:slug]
         payload
       end
@@ -81,7 +81,7 @@ describe Parametric::Schema do
     end
 
     schema = described_class.new do |sc, _opts|
-      sc.prepare slug_maker.new(:slug, from: :name)
+      sc.before_resolve slug_maker.new(:slug, from: :name)
 
       sc.field(:name).type(:string)
       sc.field(:slug).type(:string)

--- a/spec/schema_prepare_spec.rb
+++ b/spec/schema_prepare_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Parametric::Schema do
+  subject(:schema) do
+    described_class.new do
+      prepare do |payload, context|
+        payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
+        payload
+      end
+
+      field(:name).policy(:string).present
+      field(:slug).policy(:string).present
+      field(:variants).policy(:array).schema do
+        prepare do |payload, context|
+          payload[:slug] = "v: #{payload[:name].to_s.downcase}"
+          payload
+        end
+        field(:name).policy(:string).present
+        field(:slug).type(:string).present
+      end
+    end
+  end
+
+  it 'passes payload through prepare block, if defined' do
+    result = schema.resolve({ name: 'A name', variants: [{ name: 'A variant' }] })
+    expect(result.valid?).to be true
+    expect(result.output[:slug]).to eq 'a-name'
+    expect(result.output[:variants].first[:slug]).to eq 'v: a variant'
+  end
+end

--- a/spec/schema_prepare_spec.rb
+++ b/spec/schema_prepare_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Parametric::Schema do
   it 'passes payload through prepare block, if defined' do
     schema = described_class.new do
-      prepare do |payload, context|
+      prepare do |payload, _context|
         payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
         payload
       end
@@ -11,7 +11,7 @@ describe Parametric::Schema do
       field(:name).policy(:string).present
       field(:slug).policy(:string).present
       field(:variants).policy(:array).schema do
-        prepare do |payload, context|
+        prepare do |payload, _context|
           payload[:slug] = "v: #{payload[:name].to_s.downcase}"
           payload
         end
@@ -40,5 +40,30 @@ describe Parametric::Schema do
     results = schema.resolve({ variants: [ {name: 'no errors'}, {name: 'with errors'}]})
     expect(results.valid?).to be false
     expect(results.errors['$.variants[1]']).to eq ['nope!']
+  end
+
+  it 'copies pre-resolvers to merged schemas' do
+    schema1 = described_class.new do
+      prepare do |payload, _context|
+        payload[:slug] = payload[:name].to_s.downcase.gsub(/\s+/, '-') unless payload[:slug]
+        payload
+      end
+      field(:name).present.type(:string)
+      field(:slug).present.type(:string)
+    end
+
+    schema2 = described_class.new do
+      prepare do |payload, _context|
+        payload[:slug] = "slug-#{payload[:slug]}" if payload[:slug]
+        payload
+      end
+
+      field(:age).type(:integer)
+    end
+
+    schema3 = schema1.merge(schema2)
+
+    results = schema3.resolve({ name: 'Ismael Celis', age: 41 })
+    expect(results.output[:slug]).to eq 'slug-ismael-celis'
   end
 end


### PR DESCRIPTION
## Before and after resolve hooks

`Schema#before_resolve` can be used to register blocks to modify the entire input payload _before_ individual fields are validated and coerced.
This can be useful when you need to pre-populate fields relative to other fields' values, or fetch extra data from other sources.

```ruby
# This example computes the value of the :slug field based on :name
schema = Parametric::Schema.new do
  # Note1: These blocks run before field validations, so :name might be blank or invalid at this point.
  # Note2: Before hooks _must_ return a payload hash.
  before_resolve do |payload, context|
    payload.merge(
      slug: payload[:name].to_s.downcase.gsub(/\s+/, '-')
    )
  end

  # You still need to define the fields you want
  field(:name).type(:string).present
  field(:slug).type(:string).present
end

result = schema.resolve( name: 'Joe Bloggs' )
result.output # => { name: 'Joe Bloggs', slug: 'joe-bloggs' }
```

Before hooks can be added to nested schemas, too:

```ruby
schema = Parametric::Schema.new do
  field(:friends).type(:array).schema do
    before_resolve do |friend_payload, context|
      friend_payload.merge(title: "Mr/Ms #{friend_payload[:name]}")
    end

    field(:name).type(:string)
    field(:title).type(:string)
  end
end
```

You can use inline blocks, but anything that responds to `#call(payload, context)` will work, too:

```ruby
class SlugMaker
  def initialize(slug_field, from:)
    @slug_field, @from = slug_field, from
  end

  def call(payload, context)
    payload.merge(
      @slug_field => payload[@from].to_s.downcase.gsub(/\s+/, '-')
    )
  end
end

schema = Parametric::Schema.new do
  before_resolve SlugMaker.new(:slug, from: :name)

  field(:name).type(:string)
  field(:slug).type(:slug)
end
```

The `context` argument can be used to add custom validation errors in a before hook block.

```ruby
schema = Parametric::Schema.new do
  before_resolve do |payload, context|
    # validate that there's no duplicate friend names
    friends = payload[:friends] || []
    if friends.any? && friends.map{ |fr| fr[:name] }.uniq.size < friends.size
      context.add_error 'friend names must be unique'
    end

    # don't forget to return the payload
    payload
  end

  field(:friends).type(:array).schema do
    field(:name).type(:string)
  end
end

result = schema.resolve(
  friends: [
    {name: 'Joe Bloggs'},
    {name: 'Joan Bloggs'},
    {name: 'Joe Bloggs'}
  ]
)

result.valid? # => false
result.errors # => {'$' => ['friend names must be unique']}
```

In most cases you should be validating individual fields using field policies. Only validate in before hooks in cases you have dependencies between fields.

`Schema#after_resolve` takes the sanitized input hash, and can be used to further validate fields that depend on eachother.

```ruby
schema = Parametric::Schema.new do
  after_resolve do |payload, ctx|
    # Add a top level error using an arbitrary key name
    ctx.add_base_error('deposit', 'cannot be greater than house price') if payload[:deposit] > payload[:house_price]
    # Or add an error keyed after the current position in the schema
    # ctx.add_error('some error') if some_condition
    # after_resolve hooks must also return the payload, or a modified copy of it
    # note that any changes added here won't be validated.
    payload.merge(desc: 'hello')
  end

  field(:deposit).policy(:integer).present
  field(:house_price).policy(:integer).present
  field(:desc).policy(:string)
end

result = schema.resolve({ deposit: 1100, house_price: 1000 })
result.valid? # false
result.output[:deposit] # 1100
result.output[:house_price] # 1000
result.output[:desc] # 'hello'
```
