### PR TITLE
Maybe policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,33 @@ Useful for parsing comma-separated query-string parameters.
 field(:status).policy(:split) # turns "pending,confirmed" into ["pending", "confirmed"]
 ```
 
+### :maybe (optional values)
+
+Fields support a `.maybe(type_policy)` method that will return `nil` if the value is `nil`, or coerce to the configured type otherwise.
+
+```ruby
+schema = Parametric::Schema.new do
+  field(:age).maybe(:integer)
+end
+
+schema.resolve(age: 10).output[:age] # 10
+schema.resolve(age: "10").output[:age] # 10
+schema.resolve(age: nil).output[:age] # nil
+schema.resolve(age: nil).output.key?(:age) # true
+```
+
+By default, _maybe_ policies include nil values in the resulting hash.
+You can make them omit the key entirely with `omit_if_nil: true`.
+
+```ruby
+schema = Parametric::Schema.new do
+  field(:age).maybe(:integer, omit_if_nil: true)
+end
+
+schema.resolve(age: nil).output[:age] # nil
+schema.resolve(age: nil).output.key?(:age) # false
+```
+
 ## Custom policies
 
 You can also register your own custom policy objects. A policy must implement the following methods:

--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ class MyPolicy
     true
   end
 
+  # Whether to include the key for this field in resolved output
+  # if this policy is not eligible
+  def include_non_eligible_in_ouput?
+    false
+  end
+
   # Transform the value
   def coerce(value, key, context)
     value

--- a/lib/parametric/block_validator.rb
+++ b/lib/parametric/block_validator.rb
@@ -49,6 +49,10 @@ module Parametric
       @eligible_block.call(*args)
     end
 
+    def include_non_eligible_in_ouput?
+      false
+    end
+
     def coerce(value, key, context)
       @coerce_block.call(value, key, context)
     end

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "parametric/field_dsl"
-require "parametric/maybe_policy"
 
 module Parametric
   class ConfigurationError < StandardError; end
@@ -39,11 +38,6 @@ module Parametric
       self
     end
     alias_method :type, :policy
-
-    def maybe(key, *args)
-      pol = MaybePolicy.new(lookup(key, args))
-      policy pol
-    end
 
     def schema(sc = nil, &block)
       sc = (sc ? sc : Schema.new(&block))

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -125,8 +125,21 @@ module Parametric
       raise ConfigurationError, "No policies defined for #{key.inspect}" unless obj
 
       pol = obj.respond_to?(:new) ? obj.new(*args) : obj
-      obj = PolicyWithKey.new(obj, key)
-      adapt_policy(pol)
+      adapt_policy(pol, key)
+    end
+
+    # Decorate policies to implement latest interface, if some
+    # methods are missing.
+    def adapt_policy(pol, key)
+      pol = PolicyWithKey.new(pol, key)
+      pol = PolicyWithIncludeNonEligible.new(pol) unless pol.respond_to?(:include_non_eligible_in_ouput?)
+      pol
+    end
+
+    class PolicyWithIncludeNonEligible < SimpleDelegator
+      def include_non_eligible_in_ouput?
+        false
+      end
     end
 
     class PolicyWithKey < SimpleDelegator
@@ -135,19 +148,6 @@ module Parametric
       def initialize(policy, key)
         super policy
         @key = key
-      end
-    end
-
-    # Decorate policies to implement latest interface, if some
-    # methods are missing.
-    def adapt_policy(pol)
-      pol = PolicyWithIncludeNonEligible.new(pol) unless pol.respond_to?(:include_non_eligible_in_ouput?)
-      pol
-    end
-
-    class PolicyWithIncludeNonEligible < SimpleDelegator
-      def include_non_eligible_in_ouput?
-        false
       end
     end
   end

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "parametric/field_dsl"
+require "parametric/maybe_policy"
 
 module Parametric
   class ConfigurationError < StandardError; end
@@ -38,6 +39,11 @@ module Parametric
       self
     end
     alias_method :type, :policy
+
+    def maybe(key, *args)
+      pol = MaybePolicy.new(lookup(key, args))
+      policy pol
+    end
 
     def schema(sc = nil, &block)
       sc = (sc ? sc : Schema.new(&block))

--- a/lib/parametric/field_dsl.rb
+++ b/lib/parametric/field_dsl.rb
@@ -26,7 +26,9 @@ module Parametric
     end
 
     def maybe(key, *args)
-      policy MaybePolicy.new(lookup(key, args))
+      opts = args.last || {}
+      omit_if_nil = opts.delete(:omit_if_nil) || false
+      policy MaybePolicy.new(lookup(key, args), omit_if_nil: omit_if_nil)
     end
   end
 end

--- a/lib/parametric/field_dsl.rb
+++ b/lib/parametric/field_dsl.rb
@@ -26,8 +26,7 @@ module Parametric
     end
 
     def maybe(key, *args)
-      pol = MaybePolicy.new(lookup(key, args))
-      policy pol
+      policy MaybePolicy.new(lookup(key, args))
     end
   end
 end

--- a/lib/parametric/field_dsl.rb
+++ b/lib/parametric/field_dsl.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "parametric/maybe_policy"
+
 module Parametric
   # Field DSL
   # host instance must implement:
@@ -21,6 +23,11 @@ module Parametric
 
     def options(opts)
       policy :options, opts
+    end
+
+    def maybe(key, *args)
+      pol = MaybePolicy.new(lookup(key, args))
+      policy pol
     end
   end
 end

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -10,7 +10,11 @@ module Parametric
       value.nil? ? nil : policy.coerce(value, key, context)
     end
 
-    def_delegators :policy, :eligible?, :valid?, :meta_data
+    def valid?(value, key, payload)
+      value.nil? ? true : policy.valid?(value, key, payload)
+    end
+
+    def_delegators :policy, :eligible?, :meta_data, :message
 
     private
 

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -16,7 +16,11 @@ module Parametric
       value.nil? ? true : policy.valid?(value, key, payload)
     end
 
-    def_delegators :policy, :eligible?, :meta_data, :message
+    def eligible?(value, key, payload)
+      value.nil? ? false : policy.eligible?(value, key, payload)
+    end
+
+    def_delegators :policy, :meta_data, :message
 
     private
 

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -20,6 +20,10 @@ module Parametric
       value.nil? ? false : policy.eligible?(value, key, payload)
     end
 
+    def include_non_eligible_in_ouput?
+      true
+    end
+
     def_delegators :policy, :meta_data, :message
 
     private

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -7,7 +7,7 @@ module Parametric
     end
 
     def coerce(value, key, context)
-      value ? policy.coerce(value, key, context) : nil
+      value.nil? ? nil : policy.coerce(value, key, context)
     end
 
     def_delegators :policy, :eligible?, :valid?, :meta_data

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Parametric
   class MaybePolicy
     extend Forwardable

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -1,0 +1,19 @@
+module Parametric
+  class MaybePolicy
+    extend Forwardable
+
+    def initialize(policy)
+      @policy = policy
+    end
+
+    def coerce(value, key, context)
+      value ? policy.coerce(value, key, context) : nil
+    end
+
+    def_delegators :policy, :eligible?, :valid?, :meta_data
+
+    private
+
+    attr_reader :policy
+  end
+end

--- a/lib/parametric/maybe_policy.rb
+++ b/lib/parametric/maybe_policy.rb
@@ -4,8 +4,9 @@ module Parametric
   class MaybePolicy
     extend Forwardable
 
-    def initialize(policy)
+    def initialize(policy, omit_if_nil: false)
       @policy = policy
+      @omit_if_nil = omit_if_nil
     end
 
     def coerce(value, key, context)
@@ -21,7 +22,7 @@ module Parametric
     end
 
     def include_non_eligible_in_ouput?
-      true
+      !@omit_if_nil
     end
 
     def_delegators :policy, :meta_data, :message

--- a/lib/parametric/schema.rb
+++ b/lib/parametric/schema.rb
@@ -132,6 +132,10 @@ module Parametric
       true
     end
 
+    def include_non_eligible_in_ouput?
+      false
+    end
+
     def meta_data
       {}
     end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -9,6 +9,7 @@ describe 'maybe policy' do
     expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
     expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
+    expect(schema.resolve({ age: false }).output[:age]).to be false
     expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
   end
 end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'maybe policy' do
+  specify do
+    schema = Parametric::Schema.new do
+      field(:age).maybe(:integer)
+    end
+
+    expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
+    expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
+    expect(schema.resolve({ age: nil }).output[:age]).to eq nil
+  end
+end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'maybe policy' do
-  specify do
+  specify 'dealing with nil values' do
     schema = Parametric::Schema.new do
       field(:age).maybe(:integer)
     end
@@ -10,6 +10,45 @@ describe 'maybe policy' do
     expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
     expect(schema.resolve({ age: false }).output[:age]).to be false
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
+  end
+
+  specify 'interacting with types that validate' do
+    Parametric.policy :validating_integer do
+      exp = /^\d+$/
+
+      validate do |value, _key, _context|
+        !!(value.to_s =~ exp)
+      end
+
+      coerce do |value, _key, _context|
+        if value.to_s =~ exp
+          value.to_i
+        else
+          value
+        end
+      end
+
+      message do
+        'error!'
+      end
+    end
+
+    schema = Parametric::Schema.new do
+      field(:age).maybe(:validating_integer)
+    end
+
+    expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
+    expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
+    schema.resolve({ age: 'nope' }).tap do |r|
+      expect(r.output[:age]).to eq 'nope'
+      expect(r.errors.any?).to be true
+    end
+    schema.resolve({ age: nil }).tap do |r|
+      expect(r.output[:age]).to eq nil
+      expect(r.errors.any?).to be false
+    end
+    expect(schema.resolve({ age: nil }).output[:age]).to eq nil
     expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
   end
 end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -10,7 +10,7 @@ describe 'maybe policy' do
     expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
     expect(schema.resolve({ age: false }).output[:age]).to be false
-    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be true
   end
 
   specify 'interacting with types that validate' do
@@ -45,11 +45,12 @@ describe 'maybe policy' do
       expect(r.errors.any?).to be true
     end
     schema.resolve({ age: nil }).tap do |r|
+      expect(r.output.key?(:age)).to be(true)
       expect(r.output[:age]).to eq nil
       expect(r.errors.any?).to be false
     end
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
-    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be true
   end
 
   specify 'interacting with required fields' do
@@ -58,6 +59,7 @@ describe 'maybe policy' do
     end
 
     result = schema.resolve({})
+    expect(result.output.key?(:age)).to be(true)
     expect(result.output[:age]).to eq nil
     expect(result.errors['$.age']).to eq nil
   end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -51,4 +51,14 @@ describe 'maybe policy' do
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
     expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
   end
+
+  specify 'interacting with required fields' do
+    schema = Parametric::Schema.new do
+      field(:age).maybe(:integer).required
+    end
+
+    result = schema.resolve({})
+    expect(result.output[:age]).to eq nil
+    expect(result.errors['$.age']).to eq nil
+  end
 end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -79,4 +79,12 @@ describe 'maybe policy' do
     expect(result.output[:age]).to eq nil
     expect(result.errors['$.age']).to eq nil
   end
+
+  specify 'ommiting nil values from output' do
+    schema = Parametric::Schema.new do
+      field(:age).maybe(:integer, omit_if_nil: true)
+    end
+    result = schema.resolve({})
+    expect(result.output.key?(:age)).to be(false)
+  end
 end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -61,4 +61,20 @@ describe 'maybe policy' do
     expect(result.output[:age]).to eq nil
     expect(result.errors['$.age']).to eq nil
   end
+
+  specify 'copying policies via Field#from' do
+    source_schema = Parametric::Schema.new do
+      field(:age).maybe(:integer).required
+    end
+
+    target_schema = Parametric::Schema.new do |sc, _|
+      source_schema.fields.each do |key, f|
+        sc.field(key).from(f)
+      end
+    end
+
+    result = target_schema.resolve({})
+    expect(result.output[:age]).to eq nil
+    expect(result.errors['$.age']).to eq nil
+  end
 end

--- a/spec/maybe_policy_spec.rb
+++ b/spec/maybe_policy_spec.rb
@@ -9,5 +9,6 @@ describe 'maybe policy' do
     expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
     expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
     expect(schema.resolve({ age: nil }).output[:age]).to eq nil
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be false
   end
 end


### PR DESCRIPTION
## What

Add a `.maybe(type_policy)` method that will return `nil` if the value is `nil`, or coerce to the configured type otherwise.

```ruby
schema = Parametric::Schema.new do
  field(:age).maybe(:integer)
end

schema.resolve(age: 10).output[:age] # 10
schema.resolve(age: "10").output[:age] # 10
schema.resolve(age: nil).output[:age] # nil
```

