### PR TITLE
Field#from

### DIFF
--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -45,6 +45,15 @@ module Parametric
       policy sc.schema
     end
 
+    def from(another_field)
+      meta another_field.meta_data
+      another_field.policies.each do |plc|
+        policies << plc
+      end
+
+      self
+    end
+
     def visit(meta_key = nil, &visitor)
       if sc = meta_data[:schema]
         r = sc.visit(meta_key, &visitor)
@@ -85,8 +94,13 @@ module Parametric
       Result.new(eligible, value)
     end
 
+    protected
+
+    attr_reader :policies
+
     private
-    attr_reader :policies, :registry, :default_block
+
+    attr_reader :registry, :default_block
 
     def resolve_one(policy, value, context)
       begin

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -112,6 +112,20 @@ describe Parametric::Field do
     end
   end
 
+  describe '#from' do
+    it 'copies policies and metadata from an existing field' do
+      subject.policy(:string).present.options(['a', 'b', 'c'])
+
+      field = described_class.new(:another_key, registry).from(subject)
+      resolve(field, another_key: "abc").tap do |r|
+        has_errors
+      end
+      expect(field.meta_data[:type]).to eq(:string)
+      expect(field.meta_data[:present]).to be(true)
+      expect(field.meta_data[:options]).to eq(['a', 'b', 'c'])
+    end
+  end
+
   describe "#present" do
     it "is valid if value is present" do
       resolve(subject.present, a_key: "abc").tap do |r|


### PR DESCRIPTION
Add a `#from(another_field)` method, to allow copying field metadata and policies from one schema to another.

```ruby
s1 = Parametric::Schema.new do |sc, _|
  sc.field(:rate_type).type(:string).present.options(['fixed', 'variable'])
end

s2 = Parametric::Schema.new do |sc, _|
  sc.field(:some_other_key).from(s1.fields[:rate_type])
end
```
