### PR TITLE
:value policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,14 @@ Useful for parsing comma-separated query-string parameters.
 field(:status).policy(:split) # turns "pending,confirmed" into ["pending", "confirmed"]
 ```
 
+### :value
+
+A policy to return a static value
+
+```ruby
+field(:currency).policy(:value, 'gbp') # this field always resolves to 'gbp'
+```
+
 ## Custom policies
 
 You can also register your own custom policy objects. A policy must implement the following methods:

--- a/lib/parametric/policies.rb
+++ b/lib/parametric/policies.rb
@@ -26,6 +26,31 @@ module Parametric
         {}
       end
     end
+
+    class Value
+      attr_reader :message
+
+      def initialize(val, msg = 'invalid value')
+        @message = msg
+        @val = val
+      end
+
+      def eligible?(value, key, payload)
+        payload.key?(key)
+      end
+
+      def coerce(_value, _key, _context)
+        @val
+      end
+
+      def valid?(value, key, payload)
+        !payload.key?(key) || !!(value == @val)
+      end
+
+      def meta_data
+        { value: @val }
+      end
+    end
   end
 
   # Default validators
@@ -33,6 +58,7 @@ module Parametric
 
   Parametric.policy :format, Policies::Format
   Parametric.policy :email, Policies::Format.new(EMAIL_REGEXP, 'invalid email')
+  Parametric.policy :value, Policies::Value
 
   Parametric.policy :noop do
     eligible do |value, key, payload|

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -264,6 +264,16 @@ describe Parametric::Field do
     end
   end
 
+  describe ":value policy" do
+    it 'always resolves to static value' do
+      resolve(subject.policy(:value, 'hello'), a_key: "tag1,tag2").tap do |r|
+        expect(r.eligible?).to be true
+        no_errors
+        expect(r.value).to eq 'hello'
+      end
+    end
+  end
+
   describe ":declared policy" do
     it "is eligible if key exists" do
       resolve(subject.policy(:declared).present, a_key: "").tap do |r|

--- a/spec/validators_spec.rb
+++ b/spec/validators_spec.rb
@@ -9,6 +9,13 @@ describe 'default validators' do
     expect(validator.valid?(payload[key], key, payload)).to eq valid
   end
 
+  describe ':value' do
+    it {
+      test_validator({key: 'Foobar'}, :key, :value, true, true, 'Foobar')
+      test_validator({key: 'Nope'}, :key, :value, true, false, 'Foobar')
+    }
+  end
+
   describe ':format' do
     it {
       test_validator({key: 'Foobar'}, :key, :format, true, true, /^Foo/)


### PR DESCRIPTION
### :value

A policy to return a static value

```ruby
field(:currency).policy(:value, 'gbp') # this field always resolves to 'gbp'
```
