### PR TITLE
Two step policy interface

### DIFF
--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -80,26 +80,26 @@ module Parametric
       end
 
       policies.each do |policy|
-        pol = policy.build(key, value, payload:, context:)
-        if !pol.eligible?
-          eligible = false
-          if has_default?
-            eligible = true
-            value = default_block.call(key, payload, context)
-          end
-          break
-        else
-          begin
+        begin
+          pol = policy.build(key, value, payload:, context:)
+          if !pol.eligible?
+            eligible = false
+            if has_default?
+              eligible = true
+              value = default_block.call(key, payload, context)
+            end
+            break
+          else
             value = pol.value
             if !pol.valid?
               eligible = true # eligible, but has errors
               context.add_error pol.message
               break # only one error at a time
             end
-          rescue StandardError => e
-            context.add_error e.message
-            break
           end
+        rescue StandardError => e
+          context.add_error e.message
+          break
         end
       end
 

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'delegate'
-require "parametric/field_dsl"
+require 'parametric/field_dsl'
+require 'parametric/policy_adapter'
 
 module Parametric
   class ConfigurationError < StandardError; end
@@ -79,7 +80,8 @@ module Parametric
       end
 
       policies.each do |policy|
-        if !policy.eligible?(value, key, payload)
+        pol = policy.build(key, value, payload:, context:)
+        if !pol.eligible?
           eligible = false
           if has_default?
             eligible = true
@@ -87,11 +89,16 @@ module Parametric
           end
           break
         else
-          value = resolve_one(policy, value, context)
-          if !policy.valid?(value, key, payload)
-            eligible = true # eligible, but has errors
-            context.add_error policy.message
-            break # only one error at a time
+          begin
+            value = pol.value
+            if !pol.valid?
+              eligible = true # eligible, but has errors
+              context.add_error pol.message
+              break # only one error at a time
+            end
+          rescue StandardError => e
+            context.add_error e.message
+            break
           end
         end
       end
@@ -107,15 +114,6 @@ module Parametric
 
     attr_reader :registry, :default_block
 
-    def resolve_one(policy, value, context)
-      begin
-        policy.coerce(value, key, context)
-      rescue StandardError => e
-        context.add_error e.message
-        value
-      end
-    end
-
     def has_default?
       !!default_block && !meta_data[:skip_default]
     end
@@ -127,6 +125,7 @@ module Parametric
 
       obj = obj.new(*args) if obj.respond_to?(:new)
       obj = PolicyWithKey.new(obj, key)
+      obj = PolicyAdapter.new(obj) unless obj.respond_to?(:build)
 
       obj
     end

--- a/lib/parametric/policy_adapter.rb
+++ b/lib/parametric/policy_adapter.rb
@@ -8,6 +8,7 @@ module Parametric
         @policy, @key, @raw_value, @payload, @context = policy, key, value, payload, context
       end
 
+      # The Policy Runner interface
       def eligible?
         @policy.eligible?(@raw_value, @key, @payload)
       end
@@ -29,6 +30,7 @@ module Parametric
       @policy = policy
     end
 
+    # The Policy Factory interface
     def build(key, value, payload:, context:)
       PolicyRunner.new(@policy, key, value, payload, context)
     end

--- a/lib/parametric/policy_adapter.rb
+++ b/lib/parametric/policy_adapter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Parametric
+  # Adapt legacy policies to the new policy interface
+  class PolicyAdapter
+    class PolicyRunner
+      def initialize(policy, key, value, payload, context)
+        @policy, @key, @raw_value, @payload, @context = policy, key, value, payload, context
+      end
+
+      def eligible?
+        @policy.eligible?(@raw_value, @key, @payload)
+      end
+
+      def valid?
+        @policy.valid?(value, @key, @payload)
+      end
+
+      def value
+        @value ||= @policy.coerce(@raw_value, @key, @context)
+      end
+
+      def message
+        @policy.message
+      end
+    end
+
+    def initialize(policy)
+      @policy = policy
+    end
+
+    def build(key, value, payload:, context:)
+      PolicyRunner.new(@policy, key, value, payload, context)
+    end
+
+    def meta_data
+      @policy.meta_data
+    end
+
+    def key
+      @policy.key
+    end
+  end
+end

--- a/lib/parametric/policy_adapter.rb
+++ b/lib/parametric/policy_adapter.rb
@@ -8,19 +8,23 @@ module Parametric
         @policy, @key, @raw_value, @payload, @context = policy, key, value, payload, context
       end
 
-      # The Policy Runner interface
+      # The PolicyRunner interface
+      # @return [Boolean]
       def eligible?
         @policy.eligible?(@raw_value, @key, @payload)
       end
 
+      # @return [Boolean]
       def valid?
         @policy.valid?(value, @key, @payload)
       end
 
+      # @return [Any]
       def value
         @value ||= @policy.coerce(@raw_value, @key, @context)
       end
 
+      # @return [String]
       def message
         @policy.message
       end
@@ -30,7 +34,14 @@ module Parametric
       @policy = policy
     end
 
-    # The Policy Factory interface
+    # The PolicyFactory interface
+    # Buld a Policy Runner, which is instantiated
+    # for each field when resolving a schema
+    # @param key [Symbol]
+    # @param value [Any]
+    # @option payload [Hash]
+    # @option context [Parametric::Context]
+    # @return [PolicyRunner]
     def build(key, value, payload:, context:)
       PolicyRunner.new(@policy, key, value, payload, context)
     end


### PR DESCRIPTION
Change the internal Policy interface, so that policy "runners" are instantiated with field state for each field resolution,
so that more complex policies don't need to compute coercions and validations more than once.

The block-based policy builder remains the same, for backwards compatibility, but is adapted to the new interfaces internally.

In this PR, a policy consists of:

* A `PolicyFactory` interface:

```ruby
class MyPolicy
  # Initializer signature is up to you.
  # These are the arguments passed to the policy when using in a Field,
  # ex. field(:name).policy(:my_policy, 'arg1', 'arg2')
  def initialize(arg1, arg2)
    @arg1, @arg2 = arg1, arg2
  end

  # @return [Hash]
  def meta_data
   { type: :string }
  end

  # Buld a Policy Runner, which is instantiated
  # for each field when resolving a schema
  # @param key [Symbol]
  # @param value [Any]
  # @option payload [Hash]
  # @option context [Parametric::Context]
  # @return [PolicyRunner]
  def build(key, value, payload:, context:)
    MyPolicyRunner.new(key, value, payload, context)
  end
end
```

* A `PolicyRunner` interface.

```ruby
class MyPolicyRunner
  # Initializer is up to you. See `MyPolicy#build`
  def initialize(key, value, payload, context)

  end

  # Should this policy run at all?
  # returning [false] halts the field policy chain.
  # @return [Boolean]
  def eligible?
    true
  end

  # If [false], add [#message] to result errors and halt processing field.
  # @return [Boolean]
  def valid?
    true
  end

  # Coerce the value, or return as-is.
  # @return [Any]
  def value
    @value
  end

  # Error message for this policy
  # @return [String]
  def message
    "#{@value} is invalid"
  end
end
```

Then register your custom policy factory:

```ruby
Parametric.policy :my_polict, MyPolicy
```

And then refer to it by name when declaring your schema fields

```ruby
field(:title).policy(:my_policy, 'arg1', 'arg2')
```

You can chain custom policies with other policies.

```ruby
field(:title).required.policy(:my_policy, 'arg1', 'arg2')
```

Note that you can also register instances.

```ruby
Parametric.policy :my_policy, MyPolicy.new('arg1', 'arg2')
```

For example, a policy that can be configured on a field-by-field basis:

```ruby
class AddJobTitle
  def initialize(job_title)
    @job_title = job_title
  end

  def build(key, value, payload:, context:)
    Runner.new(@job_title, key, value, payload, context)
  end

  def meta_data
    {}
  end

  class Runner
    attr_reader :message

    def initialize(job_title, key, value, payload, _context)
      @job_title = job_title
      @key, @value, @payload = key, value, payload
      @message = 'is invalid'
    end

    def eligible?
      true
    end

    def valid?
      true
    end

    def value
      "#{@value}, #{@job_title}"
    end
  end
end

# Register it
Parametric.policy :job_title, AddJobTitle
```

Now you can reuse the same policy with different configuration

```ruby
manager_schema = Parametric::Schema.new do
  field(:name).type(:string).policy(:job_title, "manager")
end

cto_schema = Parametric::Schema.new do
  field(:name).type(:string).policy(:job_title, "CTO")
end

manager_schema.resolve(name: "Joe Bloggs").output # => {name: "Joe Bloggs, manager"}
cto_schema.resolve(name: "Joe Bloggs").output # => {name: "Joe Bloggs, CTO"}
```
