### PR TITLE
Tagged One Of

### DIFF
--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -3,6 +3,7 @@
 require 'delegate'
 require 'parametric/field_dsl'
 require 'parametric/policy_adapter'
+require 'parametric/one_of'
 
 module Parametric
   class ConfigurationError < StandardError; end
@@ -40,6 +41,16 @@ module Parametric
       self
     end
     alias_method :type, :policy
+
+    # field(:sub_schema).one_of do |sub|
+    #   sub.index_by { |payload| payload[:type]) }
+    #   sub.on('sub1', sub1_schema)
+    #   sub.on('sub2', sub2_schema)
+    # end
+    #
+    def one_of(&block)
+      policy Parametric::OneOf.new(&block)
+    end
 
     def schema(sc = nil, &block)
       sc = (sc ? sc : Schema.new(&block))

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -3,7 +3,7 @@
 require 'delegate'
 require 'parametric/field_dsl'
 require 'parametric/policy_adapter'
-require 'parametric/one_of'
+require 'parametric/tagged_one_of'
 
 module Parametric
   class ConfigurationError < StandardError; end
@@ -42,14 +42,8 @@ module Parametric
     end
     alias_method :type, :policy
 
-    # field(:sub_schema).one_of do |sub|
-    #   sub.index_by { |payload| payload[:type]) }
-    #   sub.on('sub1', sub1_schema)
-    #   sub.on('sub2', sub2_schema)
-    # end
-    #
-    def one_of(instance = nil, &block)
-      policy(instance || Parametric::OneOf.new(&block))
+    def tagged_one_of(instance = nil, &block)
+      policy(instance || Parametric::TaggedOneOf.new(&block))
     end
 
     def schema(sc = nil, &block)

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -48,8 +48,8 @@ module Parametric
     #   sub.on('sub2', sub2_schema)
     # end
     #
-    def one_of(&block)
-      policy Parametric::OneOf.new(&block)
+    def one_of(instance = nil, &block)
+      policy(instance || Parametric::OneOf.new(&block))
     end
 
     def schema(sc = nil, &block)

--- a/lib/parametric/one_of.rb
+++ b/lib/parametric/one_of.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Parametric
+  class OneOf
+    def initialize(&block)
+      @index = ->(payload) { payload }
+      @matchers = {}
+      block.call(self) if block_given?
+      freeze
+    end
+
+    def message
+      'could not match any sub-schema'
+    end
+
+    def index_by(callable = nil, &block)
+      callable = ->(payload) { payload[callable] } if callable.is_a?(Symbol)
+      @index = callable || block
+    end
+
+    def on(key, schema)
+      @matchers[key] = schema
+    end
+
+    def eligible?(value, key, payload)
+      payload.key?(key)
+    end
+
+    def coerce(value, key, context)
+      value
+    end
+
+    def valid?(value, key, payload)
+      @matchers.key?(payload[key])
+    end
+
+    def meta_data
+      { one_of: @matchers.keys }
+    end
+  end
+end

--- a/lib/parametric/one_of.rb
+++ b/lib/parametric/one_of.rb
@@ -1,41 +1,135 @@
 # frozen_string_literal: true
 
 module Parametric
+  # A policy that allows you to select a sub-schema based on a value in the payload.
+  # @example
+  #
+  #   user_schema = Parametric::Schema.new do |sc, _|
+  #     field(:name).type(:string).present
+  #     field(:age).type(:integer).present
+  #   end
+  #
+  #   company_schema = Parametric::Schema.new do
+  #     field(:name).type(:string).present
+  #     field(:company_code).type(:string).present
+  #   end
+  #
+  #   schema = Parametric::Schema.new do |sc, _|
+  #      # Use :type field to locate the sub-schema to use for :sub
+  #      sc.field(:type).type(:string)
+  #
+  #      # Use the :one_of policy to select the sub-schema based on the :type field above
+  #      sc.field(:sub).type(:object).one_of do |sub|
+  #        sub.index_by(:type)
+  #        sub.on('user', user)
+  #        sub.on('company', company)
+  #      end
+  #    end
+  #
+  #    # The schema will now select the correct sub-schema based on the value of :type
+  #    result = schema.resolve(type: 'user', sub: { name: 'Joe', age: 30 })
+  #
+  # Instances can also be created separately and used as a policy:
+  # @example
+  #
+  #   UserOrCompany = Parametric::OneOf.new do |sc, _|
+  #     sc.index_by(:type)
+  #     sc.on('user', user_schema)
+  #     sc.on('company', company_schema)
+  #   end
+  #
+  #   schema = Parametric::Schema.new do |sc, _|
+  #     sc.field(:type).type(:string)
+  #     sc.field(:sub).type(:object).policy(UserOrCompany)
+  #   end
   class OneOf
-    def initialize(&block)
-      @index = ->(payload) { payload }
-      @matchers = {}
-      block.call(self) if block_given?
+    NOOP_INDEX = ->(payload) { payload }.freeze
+    def initialize(index: NOOP_INDEX, matchers: {}, &block)
+      @index = index
+      @matchers = matchers
+      @configuring = false
+      if block_given?
+        @configuring = true
+        block.call(self)
+        @configuring = false
+      end
       freeze
     end
 
-    def message
-      'could not match any sub-schema'
-    end
-
     def index_by(callable = nil, &block)
-      callable = ->(payload) { payload[callable] } if callable.is_a?(Symbol)
-      @index = callable || block
+      if callable.is_a?(Symbol)
+        key = callable
+        callable = ->(payload) { payload[key] }
+      end
+      index = callable || block
+      if configuring?
+        @index = index
+      else
+        self.class.new(index:, matchers: @matchers)
+      end
     end
 
     def on(key, schema)
       @matchers[key] = schema
     end
 
-    def eligible?(value, key, payload)
-      payload.key?(key)
-    end
-
-    def coerce(value, key, context)
-      value
-    end
-
-    def valid?(value, key, payload)
-      @matchers.key?(payload[key])
+    # The [PolicyFactory] interface
+    def build(key, value, payload:, context:)
+      Runner.new(@index, @matchers, key, value, payload, context)
     end
 
     def meta_data
-      { one_of: @matchers.keys }
+      { type: :object, one_of: @matchers }
+    end
+
+    private def configuring?
+      @configuring
+    end
+
+    class Runner
+      def initialize(index, matchers, key, value, payload, context)
+        @matchers = matchers
+        @key = key
+        @raw_value = value
+        @payload = payload
+        @context = context
+        @index_value = index.call(payload)
+      end
+
+      # Should this policy run at all?
+      # returning [false] halts the field policy chain.
+      # @return [Boolean]
+      def eligible?
+        true
+      end
+
+      # If [false], add [#message] to result errors and halt processing field.
+      # @return [Boolean]
+      def valid?
+        has_sub_schema?
+      end
+
+      # Coerce the value, or return as-is.
+      # @return [Any]
+      def value
+        @value ||= has_sub_schema? ? sub_schema.coerce(@raw_value, @key, @context) : @raw_value
+      end
+
+      # Error message for this policy
+      # @return [String]
+      def message
+        "#{@value} is invalid. No sub-schema found for '#{@index_value}'"
+      end
+
+      private
+
+      def has_sub_schema?
+        @matchers.key?(@index_value)
+      end
+
+      def sub_schema
+        @sub_schema ||= @matchers[@index_value]
+      end
     end
   end
 end

--- a/lib/parametric/tagged_one_of.rb
+++ b/lib/parametric/tagged_one_of.rb
@@ -21,8 +21,8 @@ module Parametric
   #      # Use the :one_of policy to select the sub-schema based on the :type field above
   #      sc.field(:sub).type(:object).tagged_one_of do |sub|
   #        sub.index_by(:type)
-  #        sub.on('user', user)
-  #        sub.on('company', company)
+  #        sub.on('user', user_schema)
+  #        sub.on('company', company_schema)
   #      end
   #    end
   #
@@ -33,14 +33,13 @@ module Parametric
   # @example
   #
   #   UserOrCompany = Parametric::TaggedOneOf.new do |sc, _|
-  #     sc.index_by(:type)
   #     sc.on('user', user_schema)
   #     sc.on('company', company_schema)
   #   end
   #
   #   schema = Parametric::Schema.new do |sc, _|
   #     sc.field(:type).type(:string)
-  #     sc.field(:sub).type(:object).policy(UserOrCompany)
+  #     sc.field(:sub).type(:object).policy(UserOrCompany.index_by(:type))
   #   end
   class TaggedOneOf
     NOOP_INDEX = ->(payload) { payload }.freeze

--- a/lib/parametric/tagged_one_of.rb
+++ b/lib/parametric/tagged_one_of.rb
@@ -19,7 +19,7 @@ module Parametric
   #      sc.field(:type).type(:string)
   #
   #      # Use the :one_of policy to select the sub-schema based on the :type field above
-  #      sc.field(:sub).type(:object).one_of do |sub|
+  #      sc.field(:sub).type(:object).tagged_one_of do |sub|
   #        sub.index_by(:type)
   #        sub.on('user', user)
   #        sub.on('company', company)
@@ -32,7 +32,7 @@ module Parametric
   # Instances can also be created separately and used as a policy:
   # @example
   #
-  #   UserOrCompany = Parametric::OneOf.new do |sc, _|
+  #   UserOrCompany = Parametric::TaggedOneOf.new do |sc, _|
   #     sc.index_by(:type)
   #     sc.on('user', user_schema)
   #     sc.on('company', company_schema)
@@ -42,7 +42,7 @@ module Parametric
   #     sc.field(:type).type(:string)
   #     sc.field(:sub).type(:object).policy(UserOrCompany)
   #   end
-  class OneOf
+  class TaggedOneOf
     NOOP_INDEX = ->(payload) { payload }.freeze
     def initialize(index: NOOP_INDEX, matchers: {}, &block)
       @index = index

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -251,24 +251,28 @@ describe Parametric::Schema do
     end
   end
 
-  context 'with sub-schema options' do
-    it 'picks the right sub-schema' do
-      user = described_class.new do
+  describe '#one_of for multiple sub-schemas' do
+    let(:user_schema) do
+      described_class.new do
         field(:name).type(:string).present
         field(:age).type(:integer).present
       end
+    end
 
-      company = described_class.new do
+    let(:company_schema) do
+      described_class.new do
         field(:name).type(:string).present
         field(:company_code).type(:string).present
       end
+    end
 
+    it 'picks the right sub-schema' do
       schema = described_class.new do |sc, _|
         sc.field(:type).type(:string)
         sc.field(:sub).type(:object).one_of do |sub|
           sub.index_by(:type)
-          sub.on('sub1', user)
-          sub.on('company', company)
+          sub.on('user', user_schema)
+          sub.on('company', company_schema)
         end
       end
 
@@ -282,9 +286,26 @@ describe Parametric::Schema do
 
       result = schema.resolve(type: 'company', sub: { name: nil, company_code: 123 })
       expect(result.valid?).to be false
+      expect(result.errors['$.sub.name']).not_to be_empty
 
       result = schema.resolve(type: 'foo', sub: { name: 'ACME', company_code: 123 })
       expect(result.valid?).to be false
+    end
+
+    it 'can be assigned to instance and reused' do
+      user_or_company = Parametric::OneOf.new do |sub|
+        sub.on('user', user_schema)
+        sub.on('company', company_schema)
+      end
+
+      schema = described_class.new do |sc, _|
+        sc.field(:type).type(:string)
+        sc.field(:sub).type(:object).one_of(user_or_company.index_by(:type))
+      end
+
+      result = schema.resolve(type: 'user', sub: { name: 'Joe', age: 30 })
+      expect(result.valid?).to be true
+      expect(result.output).to eq({ type: 'user', sub: { name: 'Joe', age: 30 } })
     end
   end
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -251,7 +251,7 @@ describe Parametric::Schema do
     end
   end
 
-  describe '#one_of for multiple sub-schemas' do
+  describe '#tagged_one_of for multiple sub-schemas' do
     let(:user_schema) do
       described_class.new do
         field(:name).type(:string).present
@@ -269,7 +269,7 @@ describe Parametric::Schema do
     it 'picks the right sub-schema' do
       schema = described_class.new do |sc, _|
         sc.field(:type).type(:string)
-        sc.field(:sub).type(:object).one_of do |sub|
+        sc.field(:sub).type(:object).tagged_one_of do |sub|
           sub.index_by(:type)
           sub.on('user', user_schema)
           sub.on('company', company_schema)
@@ -293,14 +293,14 @@ describe Parametric::Schema do
     end
 
     it 'can be assigned to instance and reused' do
-      user_or_company = Parametric::OneOf.new do |sub|
+      user_or_company = Parametric::TaggedOneOf.new do |sub|
         sub.on('user', user_schema)
         sub.on('company', company_schema)
       end
 
       schema = described_class.new do |sc, _|
         sc.field(:type).type(:string)
-        sc.field(:sub).type(:object).one_of(user_or_company.index_by(:type))
+        sc.field(:sub).type(:object).tagged_one_of(user_or_company.index_by(:type))
       end
 
       result = schema.resolve(type: 'user', sub: { name: 'Joe', age: 30 })


### PR DESCRIPTION
Introduce `Field#tagged_one_of` to resolve a nested schema based on the value of a top-level field.

```ruby
user_schema = Parametric::Schema.new do |sc, _|
  field(:name).type(:string).present
  field(:age).type(:integer).present
end

company_schema = Parametric::Schema.new do
  field(:name).type(:string).present
  field(:company_code).type(:string).present
end

schema = Parametric::Schema.new do |sc, _|
  # Use :type field to locate the sub-schema to use for :sub
  sc.field(:type).type(:string)

  # Use the :one_of policy to select the sub-schema based on the :type field above
  sc.field(:sub).type(:object).tagged_one_of do |sub|
    sub.index_by(:type)
    sub.on('user', user_schema)
    sub.on('company', company_schema)
  end
end

# The schema will now select the correct sub-schema based on the value of :type
result = schema.resolve(type: 'user', sub: { name: 'Joe', age: 30 })

# Instances can also be created separately and used as a policy:

UserOrCompany = Parametric::TaggedOneOf.new do |sc, _|
  sc.on('user', user_schema)
  sc.on('company', company_schema)
end

schema = Parametric::Schema.new do |sc, _|
  sc.field(:type).type(:string)
  sc.field(:sub).type(:object).policy(UserOrCompany.index_by(:type))
end
```

`#index_by` can take a block to decide what value to resolve schemas by:

```ruby
sc.field(:sub).type(:object).tagged_one_of do |sub|
  sub.index_by { |payload| payload[:entity_type] }
  sub.on('user', user_schema)
  sub.on('company', company_schema)
end
```
