### PR TITLE
Nullable policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,21 @@ Like `:declared`, it stops the policy chain if a key is not in input, but it als
 field(:name).policy(:declared_no_default).present
 ```
 
+### :nullable
+
+Check that key is present in input. If value is `nil`, processing and validations stop, but key is still included in output.
+
+```ruby
+schema = Parametric::Schema.new do
+  field(:age).nullable.type(:integer).policy(:gt: 21)
+end
+
+schema.resolve(age: '22').output[:age] # 22
+schema.resolve(age: 10).errors[:age] # has error because < 21
+schema.resolve(age: nil).output[:age] # nil, no errors
+schema.resolve({}).output[:age] # nil, no errors
+```
+
 ### :gt
 
 Validate that the value is greater than a number

--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ class MyPolicyRunner
     true
   end
 
+  # If this policy is not eligible, should the key and value be included in the output?
+  # @return [Boolean]
+  def include_non_eligible_in_ouput?
+    true
+  end
+
   # If [false], add [#message] to result errors and halt processing field.
   # @return [Boolean]
   def valid?

--- a/lib/parametric/field.rb
+++ b/lib/parametric/field.rb
@@ -88,7 +88,7 @@ module Parametric
         begin
           pol = policy.build(key, value, payload:, context:)
           if !pol.eligible?
-            eligible = false
+            eligible = pol.include_non_eligible_in_ouput?
             if has_default?
               eligible = true
               value = default_block.call(key, payload, context)

--- a/lib/parametric/field_dsl.rb
+++ b/lib/parametric/field_dsl.rb
@@ -22,5 +22,9 @@ module Parametric
     def options(opts)
       policy :options, opts
     end
+
+    def nullable
+      policy :nullable
+    end
   end
 end

--- a/lib/parametric/nullable_policy.rb
+++ b/lib/parametric/nullable_policy.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Parametric
+  # A policy that allows a field to be nullable.
+  # Fields with nil values are not processed further, and the value is returned as-is.
+  # @example
+  #   field(:age).nullable.type(:integer)
+  #   field(:age).nullable.type(:integer).required
+  #
+  class NullablePolicy
+    def meta_data; {}; end
+
+    def build(key, value, payload:, context:)
+      Runner.new(key, value, payload, context)
+    end
+
+    class Runner
+      def initialize(key, value, payload, context)
+        @key = key
+        @value = value
+        @payload = payload
+        @context = context
+      end
+
+      # Should this policy run at all?
+      # returning [false] halts the field policy chain.
+      # @return [Boolean]
+      def eligible?
+        @payload.key?(@key) && !@value.nil?
+      end
+
+      # If this policy is not eligible, should the key and value be included in the output?
+      # @return [Boolean]
+      def include_non_eligible_in_ouput?
+        true
+      end
+
+      # If [false], add [#message] to result errors and halt processing field.
+      # @return [Boolean]
+      def valid?
+        true
+      end
+
+      # Coerce the value, or return as-is.
+      # @return [Any]
+      def value
+        @value
+      end
+
+      # Error message for this policy
+      # @return [String]
+      def message
+        ''
+      end
+    end
+  end
+end

--- a/lib/parametric/policies.rb
+++ b/lib/parametric/policies.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'parametric/nullable_policy'
+
 module Parametric
   module Policies
     class Format
@@ -59,6 +61,7 @@ module Parametric
   Parametric.policy :format, Policies::Format
   Parametric.policy :email, Policies::Format.new(EMAIL_REGEXP, 'invalid email')
   Parametric.policy :value, Policies::Value
+  Parametric.policy :nullable, Parametric::NullablePolicy
 
   Parametric.policy :noop do
     eligible do |value, key, payload|

--- a/lib/parametric/policy_adapter.rb
+++ b/lib/parametric/policy_adapter.rb
@@ -14,6 +14,14 @@ module Parametric
         @policy.eligible?(@raw_value, @key, @payload)
       end
 
+      # If a policy is not #eligible?, use this to decide if its key
+      # should still be included in output hash.
+      #
+      # @return [Boolean]
+      def include_non_eligible_in_ouput?
+        false
+      end
+
       # @return [Boolean]
       def valid?
         @policy.valid?(value, @key, @payload)

--- a/spec/nullable_policy_spec.rb
+++ b/spec/nullable_policy_spec.rb
@@ -17,12 +17,17 @@ describe 'nullable policy' do
 
   specify 'with required/present types' do
     schema = Parametric::Schema.new do
-      field(:age).nullable.type(:integer).present
+      field(:age).nullable.type(:integer).present.policy(:gt, 9)
     end
 
     schema.resolve({ age: '10' }).tap do |r|
       expect(r.output[:age]).to eq 10
       expect(r.errors.any?).to be false
+    end
+
+    schema.resolve({ age: '7' }).tap do |r|
+      expect(r.output[:age]).to eq 7
+      expect(r.errors.any?).to be true
     end
 
     schema.resolve({ age: nil }).tap do |r|

--- a/spec/nullable_policy_spec.rb
+++ b/spec/nullable_policy_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nullable policy' do
+  specify 'dealing with nil values' do
+    schema = Parametric::Schema.new do
+      field(:age).nullable.type(:integer)
+    end
+
+    expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
+    expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
+    expect(schema.resolve({ age: nil }).output[:age]).to eq nil
+    expect(schema.resolve({ age: false }).output[:age]).to be false
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be true
+  end
+
+  specify 'with required/present types' do
+    schema = Parametric::Schema.new do
+      field(:age).nullable.type(:integer).present
+    end
+
+    schema.resolve({ age: '10' }).tap do |r|
+      expect(r.output[:age]).to eq 10
+      expect(r.errors.any?).to be false
+    end
+
+    schema.resolve({ age: nil }).tap do |r|
+      expect(r.output[:age]).to eq nil
+      expect(r.errors.any?).to be false
+    end
+
+    schema.resolve({}).tap do |r|
+      expect(r.output.key?(:age)).to be true
+      expect(r.output[:age]).to eq nil
+      expect(r.errors.any?).to be false
+    end
+  end
+
+  specify 'interacting with custom types that validate' do
+    Parametric.policy :validating_integer do
+      exp = /^\d+$/
+
+      validate do |value, _key, _context|
+        !!(value.to_s =~ exp)
+      end
+
+      coerce do |value, _key, _context|
+        if value.to_s =~ exp
+          value.to_i
+        else
+          value
+        end
+      end
+
+      message do
+        'error!'
+      end
+    end
+
+    schema = Parametric::Schema.new do
+      field(:age).nullable.type(:validating_integer)
+    end
+
+    expect(schema.resolve({ age: 10 }).output[:age]).to eq 10
+    expect(schema.resolve({ age: '10' }).output[:age]).to eq 10
+    schema.resolve({ age: 'nope' }).tap do |r|
+      expect(r.output[:age]).to eq 'nope'
+      expect(r.errors.any?).to be true
+    end
+    schema.resolve({ age: nil }).tap do |r|
+      expect(r.output.key?(:age)).to be(true)
+      expect(r.output[:age]).to eq nil
+      expect(r.errors.any?).to be false
+    end
+    expect(schema.resolve({ age: nil }).output[:age]).to eq nil
+    expect(schema.resolve({ nope: 1 }).output.key?(:age)).to be true
+  end
+
+  specify 'interacting with required fields' do
+    schema = Parametric::Schema.new do
+      field(:age).nullable.type(:integer).required
+    end
+
+    result = schema.resolve({})
+    expect(result.output.key?(:age)).to be(true)
+    expect(result.output[:age]).to eq nil
+    expect(result.errors['$.age']).to eq nil
+  end
+
+  specify 'copying policies via Field#from' do
+    source_schema = Parametric::Schema.new do
+      field(:age).nullable.type(:integer).required
+    end
+
+    target_schema = Parametric::Schema.new do |sc, _|
+      source_schema.fields.each do |key, f|
+        sc.field(key).from(f)
+      end
+    end
+
+    result = target_schema.resolve({})
+    expect(result.output[:age]).to eq nil
+    expect(result.errors['$.age']).to eq nil
+  end
+end


### PR DESCRIPTION
Check that key is present in input. If value is `nil`, processing and validations stop, but key is still included in output.

```ruby
schema = Parametric::Schema.new do
  field(:age).nullable.type(:integer).policy(:gt: 21)
end

schema.resolve(age: '22').output[:age] # 22
schema.resolve(age: 10).errors[:age] # has error because < 21
schema.resolve(age: nil).output[:age] # nil, no errors
schema.resolve({}).output[:age] # nil, no errors
```
