### PR TITLE
Field wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,30 @@ instance.data # => #<MyStruct::Data2:...> (User struct)
 instance.data.name # => 'Joe'
 ```
 
-## Built-in policies
+## `wrap`
+
+This helper turns a custom object into a policy. The object must respond to `.coerce(value)` and return something that responds to `#errors() Hash`.
+
+```ruby
+UserType = Data.define(:name) do
+  def self.coerce(value)
+    return value if value.is_a?(self)
+    new(value)
+  end
+
+  def errors
+    return { name: ['cannot be blank'] } if name.nil? || name.strip.empty?
+    {}
+  end
+end
+
+schema = Parametric::Schema.new do
+  field(:user).wrap(UserType).present
+end
+
+```
+
+## Built-in policies                                             
 
 Type coercions (the `type` method) and validations (the `validate` method) are all _policies_.
 

--- a/lib/parametric/wrapper.rb
+++ b/lib/parametric/wrapper.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Parametric
+  # A policy wrapper that delegates type coercion and validation to external objects.
+  #
+  # This allows integration of custom types, domain objects, or value objects that
+  # implement their own coercion and validation logic into Parametric schemas.
+  #
+  # The wrapped object must implement:
+  # - `coerce(value)`: Method to convert input values to the desired type
+  # - The returned object must have an `errors` method that returns validation errors
+  #
+  # @example Basic usage
+  #   Money = Data.define(:amount, :currency) do
+  #     def self.coerce(value)
+  #       case value
+  #       when Hash
+  #         new(value[:amount], value[:currency])
+  #       when String
+  #         parts = value.split(' ')
+  #         new(parts[0].to_f, parts[1])
+  #       else
+  #         new(value, 'USD')
+  #       end
+  #     end
+  #
+  #     def errors
+  #       errors = {}
+  #       errors[:amount] = ['must be positive'] if amount <= 0
+  #       errors[:currency] = ['invalid'] unless %w[USD EUR GBP].include?(currency)
+  #       errors
+  #     end
+  #   end
+  #
+  #   field(:price).wrap(Money)
+  #
+  # @see Field#wrap
+  class Wrapper
+    # Initialize the wrapper with a caster object.
+    #
+    # @param caster [Object] Object that responds to `coerce(value)` method
+    def initialize(caster)
+      @caster = caster
+    end
+
+    # Build a policy runner for this wrapper.
+    #
+    # @param key [Symbol] The field key being processed
+    # @param value [Object] The input value to be coerced and validated
+    # @param payload [Hash] The complete input payload (unused)
+    # @param context [Context] The validation context (unused)
+    # @return [Runner] A runner instance that handles the coercion and validation
+    def build(key, value, payload:, context:)
+      Runner.new(@caster, key, value)
+    end
+
+    # Return metadata about this policy.
+    #
+    # @return [Hash] Metadata hash containing the wrapper type
+    def meta_data
+      { type: @caster }
+    end
+
+    # Policy runner that executes the wrapper's coercion and validation logic.
+    #
+    # This class implements the policy runner interface required by Parametric's
+    # policy system. It delegates coercion to the wrapper object and collects
+    # validation errors from the coerced value.
+    class Runner
+      attr_reader :key, :value
+
+      # Initialize the runner with coercion logic.
+      #
+      # @param caster [Object] Object that responds to `coerce(value)`
+      # @param key [Symbol] The field key being processed
+      # @param value [Object] The input value to be coerced and validated
+      def initialize(caster, key, value)
+        @caster = caster
+        @key = key
+        @value = caster.coerce(value)
+        @errors = @value.errors
+      end
+
+      # Check if this policy should run.
+      #
+      # @return [Boolean] Always returns true for wrapper policies
+      def eligible?
+        true
+      end
+
+      # Check if the coerced value is valid.
+      #
+      # @return [Boolean] True if no validation errors, false otherwise
+      def valid? = @errors.empty?
+
+      # Generate a human-readable error message from validation errors.
+      #
+      # @return [String] Formatted error message combining all validation errors
+      def message = @errors.map { |k, v| "#{k} #{v.join(', ')}" }.join('. ')
+    end
+  end
+end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -274,6 +274,44 @@ describe Parametric::Schema do
     end
   end
 
+  describe '#wrap' do
+    let(:schema) do
+      described_class.new do |sc, _|
+        sc.field(:user).wrap(user_type).present
+      end
+    end
+
+    let(:user_type) do
+      Data.define(:name) do
+        def self.coerce(value)
+          return value if value.is_a?(self)
+
+          new(value)
+        end
+
+        def errors
+          return { name: ['cannot be blank'] } if name.nil? || name.strip.empty?
+
+          {}
+        end
+      end
+    end
+
+    it 'delegates to .cast, #valid? interface' do
+      result = schema.resolve(user: 'Joe')
+      expect(result.valid?).to be true
+      expect(result.output[:user]).to eq(user_type.new('Joe'))
+
+      result = schema.resolve(user: '')
+      expect(result.valid?).to be false
+      expect(result.errors['$.user']).to eq ['name cannot be blank']
+
+      result = schema.resolve(user: user_type.new('Joe'))
+      expect(result.valid?).to be true
+      expect(result.output[:user]).to eq(user_type.new('Joe'))
+    end
+  end
+
   describe '#one_of' do
     let(:kwh_schema) do
       described_class.new do

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -297,7 +297,7 @@ describe Parametric::Schema do
       end
     end
 
-    it 'delegates to .cast, #valid? interface' do
+    it 'delegates to .coerce, #errors interface' do
       result = schema.resolve(user: 'Joe')
       expect(result.valid?).to be true
       expect(result.output[:user]).to eq(user_type.new('Joe'))
@@ -309,6 +309,10 @@ describe Parametric::Schema do
       result = schema.resolve(user: user_type.new('Joe'))
       expect(result.valid?).to be true
       expect(result.output[:user]).to eq(user_type.new('Joe'))
+    end
+
+    it 'does not break #walk' do
+      expect(schema.walk(:default).output).to be_a(Hash)
     end
   end
 


### PR DESCRIPTION
## `wrap`

This helper turns a custom object into a policy. The object must respond to `.coerce(value)` and return something that responds to `#errors() Hash`.

```ruby
UserType = Data.define(:name) do
  def self.coerce(value)
    return value if value.is_a?(self)
    new(value)
  end

  def errors
    return { name: ['cannot be blank'] } if name.nil? || name.strip.empty?
    {}
  end
end

schema = Parametric::Schema.new do
  field(:user).wrap(UserType).present
end
```
